### PR TITLE
Implements clear-chat function on graphql-server

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/chat/ClearPublicChatHistoryPubMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/chat/ClearPublicChatHistoryPubMsgHdlr.scala
@@ -3,6 +3,7 @@ package org.bigbluebutton.core.apps.chat
 import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.apps.{ ChatModel, PermissionCheck, RightsManagementTrait }
 import org.bigbluebutton.core.bus.MessageBus
+import org.bigbluebutton.core.db.ChatMessageDAO
 import org.bigbluebutton.core.running.{ LiveMeeting, LogHelper }
 import org.bigbluebutton.core.domain.MeetingState2x
 
@@ -31,6 +32,8 @@ trait ClearPublicChatHistoryPubMsgHdlr extends LogHelper with RightsManagementTr
       val newState = for {
         gc <- state.groupChats.find(msg.body.chatId)
       } yield {
+        ChatMessageDAO.deleteAllFromChat(liveMeeting.props.meetingProp.intId, msg.body.chatId)
+        ChatMessageDAO.insertSystemMsg(liveMeeting.props.meetingProp.intId, msg.body.chatId, "", "publicChatHistoryCleared", Map(), "")
         broadcastEvent(msg)
         val newGc = gc.clearMessages()
         val gcs = state.groupChats.update(newGc)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/ChatMessageDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/ChatMessageDAO.scala
@@ -99,4 +99,16 @@ object ChatMessageDAO {
     }
   }
 
+  def deleteAllFromChat(meetingId: String, chatId: String) = {
+    DatabaseConnection.db.run(
+      TableQuery[ChatMessageDbTableDef]
+        .filter(_.meetingId === meetingId)
+        .filter(_.chatId === chatId)
+        .delete
+    ).onComplete {
+      case Success(rowsAffected) => DatabaseConnection.logger.debug(s"$rowsAffected row(s) deleted from ChatMessage meetingId=${meetingId} chatId=${chatId}")
+      case Failure(e) => DatabaseConnection.logger.error(s"Error deleting from ChatMessage meetingId=${meetingId} chatId=${chatId}: $e")
+    }
+  }
+
 }


### PR DESCRIPTION
A system-msg with `messageType: publicChatHistoryCleared` will be sent to the cleared chat!