### PR TITLE
gql-middleware: Migrate graphQL ws transport to `graphql-transport-ws`

### DIFF
--- a/bbb-graphql-middleware/demo/client/main.js
+++ b/bbb-graphql-middleware/demo/client/main.js
@@ -31,7 +31,7 @@ ws.onopen = (event) => {
       
       const payload = { variables:{}, extensions: {}, query: query };
     //   console.log(`Sending: ${JSON.stringify(payload)}`);
-      ws.send(JSON.stringify({id:"1", type: "start", payload }));
+      ws.send(JSON.stringify({id:"1", type: "subscribe", payload }));
       
 }
 

--- a/bbb-graphql-middleware/internal/gql_actions/client.go
+++ b/bbb-graphql-middleware/internal/gql_actions/client.go
@@ -48,7 +48,7 @@ RangeLoop:
 
 				var fromBrowserMessageAsMap = fromBrowserMessage.(map[string]interface{})
 
-				if fromBrowserMessageAsMap["type"] == "start" {
+				if fromBrowserMessageAsMap["type"] == "subscribe" {
 					queryId := fromBrowserMessageAsMap["id"].(string)
 					payload := fromBrowserMessageAsMap["payload"].(map[string]interface{})
 
@@ -60,7 +60,7 @@ RangeLoop:
 								//Action sent successfully, return data msg to client
 								browserResponseData := map[string]interface{}{
 									"id":   queryId,
-									"type": "data",
+									"type": "next",
 									"payload": map[string]interface{}{
 										"data": map[string]interface{}{
 											funcName: true,

--- a/bbb-graphql-middleware/internal/hasura/conn/reader/reader.go
+++ b/bbb-graphql-middleware/internal/hasura/conn/reader/reader.go
@@ -66,11 +66,11 @@ func handleMessageReceivedFromHasura(hc *common.HasuraConnection, fromHasuraToBr
 				common.ActivitiesOverviewCompleted("_Sum-" + string(subscription.Type))
 			}
 
-			if messageType == "data" {
+			if messageType == "next" {
 				common.ActivitiesOverviewDataReceived(string(subscription.Type) + "-" + subscription.OperationName)
 			}
 
-			if messageType == "data" &&
+			if messageType == "next" &&
 				subscription.Type == common.Subscription {
 				hasNoPreviousOccurrence := handleSubscriptionMessage(hc, messageMap, subscription, queryId)
 

--- a/bbb-graphql-middleware/internal/hasura/conn/writer/writer.go
+++ b/bbb-graphql-middleware/internal/hasura/conn/writer/writer.go
@@ -55,7 +55,7 @@ RangeLoop:
 
 				var fromBrowserMessageAsMap = fromBrowserMessage.(map[string]interface{})
 
-				if fromBrowserMessageAsMap["type"] == "start" {
+				if fromBrowserMessageAsMap["type"] == "subscribe" {
 					var queryId = fromBrowserMessageAsMap["id"].(string)
 
 					//Identify type based on query string
@@ -154,7 +154,7 @@ RangeLoop:
 					//saveItToFile(fmt.Sprintf("%s-%s-%02s", string(messageType), operationName, queryId), fromBrowserMessageAsMap)
 				}
 
-				if fromBrowserMessageAsMap["type"] == "stop" {
+				if fromBrowserMessageAsMap["type"] == "complete" {
 					var queryId = fromBrowserMessageAsMap["id"].(string)
 					browserConnection.ActiveSubscriptionsMutex.RLock()
 					jsonPatchSupported := browserConnection.ActiveSubscriptions[queryId].JsonPatchSupported

--- a/build/packages-template/bbb-graphql-middleware/graphql.nginx
+++ b/build/packages-template/bbb-graphql-middleware/graphql.nginx
@@ -11,7 +11,7 @@ location /graphql {
 	proxy_set_header Upgrade $http_upgrade;
 	proxy_set_header Connection "Upgrade";
 	proxy_set_header Host $host;
-	#proxy_pass         http://127.0.0.1:8085; #Hasura
+	#proxy_pass         http://127.0.0.1:8085; #Hasura (it requires to change the location to /v1/graphql)
 	proxy_pass         http://127.0.0.1:8378; #Graphql Middleware
 }
 


### PR DESCRIPTION
After conducting some tests, I found that migrating to `graphql-transport-ws` is as simple as renaming some messages types:

`start` -> `subscribe`
`data` -> `next`
`stop` -> `complete`
`keep_alive` -> `ping` / `pong` (the middleware simply forwards these)

Aside from these changes, the overall structure remains the same.

More details at:
https://github.com/enisdenjo/graphql-ws/blob/master/PROTOCOL.md