### PR TITLE
Use `URIBuilder` for Reliable URL Parameter Removal

### DIFF
--- a/akka-bbb-apps/project/Dependencies.scala
+++ b/akka-bbb-apps/project/Dependencies.scala
@@ -24,6 +24,7 @@ object Dependencies {
     // Apache Commons
     val lang = "3.12.0"
     val codec = "1.15"
+    val httpcomponents = "4.5.14"
 
     // BigBlueButton
     val bbbCommons = "0.0.22-SNAPSHOT"
@@ -60,6 +61,7 @@ object Dependencies {
     val pekkoHttpSprayJson = "org.apache.pekko" %% "pekko-http-spray-json" % Versions.pekkoHttpVersion
 
     val apacheLang = "org.apache.commons" % "commons-lang3" % Versions.lang
+    val apacheHttpComponents = "org.apache.httpcomponents" % "httpclient" % Versions.httpcomponents
 
     val bbbCommons = "org.bigbluebutton" % "bbb-common-message_2.13" % Versions.bbbCommons
 
@@ -101,6 +103,7 @@ object Dependencies {
     Compile.sprayJson,
     Compile.semver,
     Compile.apacheLang,
+    Compile.apacheHttpComponents,
     Compile.pekkoHttp,
     Compile.pekkoHttpSprayJson,
     Compile.bbbCommons,

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/externalvideo/StartExternalVideoPubMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/externalvideo/StartExternalVideoPubMsgHdlr.scala
@@ -39,9 +39,9 @@ trait StartExternalVideoPubMsgHdlr extends RightsManagementTrait {
       // Request a screen broadcast stop (goes to SFU, comes back through
       // ScreenshareRtmpBroadcastStoppedVoiceConfEvtMsg)
       requestBroadcastStop(bus.outGW, liveMeeting)
-      val (url, seconds) = UrlTimeExtractor.extractTime(msg.body.externalVideoUrl)
-      ExternalVideoModel.setURL(liveMeeting.externalVideoModel, url)
-      ExternalVideoDAO.insert(liveMeeting.props.meetingProp.intId, url, seconds)
+      val (videoUrl, initialSecond) = UrlTimeExtractor.extractTime(msg.body.externalVideoUrl)
+      ExternalVideoModel.setURL(liveMeeting.externalVideoModel, videoUrl)
+      ExternalVideoDAO.insert(liveMeeting.props.meetingProp.intId, videoUrl, initialSecond)
       broadcastEvent(msg)
     }
   }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/ExternalVideoDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/ExternalVideoDAO.scala
@@ -30,7 +30,7 @@ class ExternalVideoDbTableDef(tag: Tag) extends Table[ExternalVideoDbModel](tag,
 }
 
 object ExternalVideoDAO {
-  def insert(meetingId: String, externalVideoUrl: String, timestamp: Double): Unit = {
+  def insert(meetingId: String, externalVideoUrl: String, initialTime: Double): Unit = {
     DatabaseConnection.enqueue(
       TableQuery[ExternalVideoDbTableDef].forceInsert(
         ExternalVideoDbModel(
@@ -41,7 +41,7 @@ object ExternalVideoDAO {
           stoppedSharingAt = None,
           updatedAt = new java.sql.Timestamp(System.currentTimeMillis()),
           playerPlaybackRate = 1,
-          playerCurrentTime = timestamp,
+          playerCurrentTime = initialTime,
           playerPlaying = true
         )
       )


### PR DESCRIPTION
Using regex to remove the time parameter has some shortcomings.
For instance, the URL `https://youtu.be/SHxupUGhn4U?t=382&si=klYJsOCf8mzSigMW`
gets incorrectly converted to `https://youtu.be/SHxupUGhn4U&si=klYJsOCf8mzSigMW`,
where the first query parameter should come after a `?`, not an `&`.

This PR replaces the regex approach with `URIBuilder` from `org.apache.httpcomponents`,
which provides a more reliable way to parse and manipulate URL parameters.
