### PR TITLE
feat: add lockSettings option to disabledFeatures

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ChangeLockSettingsInMeetingCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ChangeLockSettingsInMeetingCmdMsgHdlr.scala
@@ -19,7 +19,12 @@ trait ChangeLockSettingsInMeetingCmdMsgHdlr extends RightsManagementTrait {
 
   def handleSetLockSettings(msg: ChangeLockSettingsInMeetingCmdMsg): Unit = {
 
-    if (permissionFailed(PermissionCheck.MOD_LEVEL, PermissionCheck.VIEWER_LEVEL, liveMeeting.users2x, msg.header.userId) || liveMeeting.props.meetingProp.isBreakout) {
+    if (liveMeeting.props.meetingProp.disabledFeatures.contains("lockSettings")) {
+      log.warning(
+        "Ignoring lock settings change because the lockSettings feature is disabled for meeting {}",
+        liveMeeting.props.meetingProp.intId
+      )
+    } else if (permissionFailed(PermissionCheck.MOD_LEVEL, PermissionCheck.VIEWER_LEVEL, liveMeeting.users2x, msg.header.userId) || liveMeeting.props.meetingProp.isBreakout) {
       val meetingId = liveMeeting.props.meetingProp.intId
       val reason = "No permission to change lock settings"
       PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, outGW, liveMeeting)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/LockUserInMeetingCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/LockUserInMeetingCmdMsgHdlr.scala
@@ -24,7 +24,12 @@ trait LockUserInMeetingCmdMsgHdlr extends RightsManagementTrait {
       BbbCommonEnvCoreMsg(envelope, event)
     }
 
-    if (permissionFailed(PermissionCheck.MOD_LEVEL, PermissionCheck.VIEWER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
+    if (liveMeeting.props.meetingProp.disabledFeatures.contains("lockSettings")) {
+      log.warning(
+        "Ignoring lock user request because the lockSettings feature is disabled for meeting {}",
+        liveMeeting.props.meetingProp.intId
+      )
+    } else if (permissionFailed(PermissionCheck.MOD_LEVEL, PermissionCheck.VIEWER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
       val meetingId = liveMeeting.props.meetingProp.intId
       val reason = "No permission to lock user in meeting."
       PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, outGW, liveMeeting)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/LockUsersInMeetingCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/LockUsersInMeetingCmdMsgHdlr.scala
@@ -22,7 +22,12 @@ trait LockUsersInMeetingCmdMsgHdlr extends RightsManagementTrait {
       BbbCommonEnvCoreMsg(envelope, event)
     }
 
-    if (permissionFailed(PermissionCheck.MOD_LEVEL, PermissionCheck.VIEWER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
+    if (liveMeeting.props.meetingProp.disabledFeatures.contains("lockSettings")) {
+      log.warning(
+        "Ignoring lock users request because the lockSettings feature is disabled for meeting {}",
+        liveMeeting.props.meetingProp.intId
+      )
+    } else if (permissionFailed(PermissionCheck.MOD_LEVEL, PermissionCheck.VIEWER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
       val meetingId = liveMeeting.props.meetingProp.intId
       val reason = "No permission to lock users in meeting."
       PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, outGW, liveMeeting)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
@@ -334,7 +334,7 @@ class MeetingActor(
   }
 
   private def initLockSettings(liveMeeting: LiveMeeting, lockSettingsProp: LockSettingsProps): Unit = {
-    val settings = Permissions(
+    val baseSettings = Permissions(
       disableCam = lockSettingsProp.disableCam,
       disableMic = lockSettingsProp.disableMic,
       disablePrivChat = lockSettingsProp.disablePrivateChat,
@@ -347,6 +347,24 @@ class MeetingActor(
       hideViewersAnnotation = lockSettingsProp.hideViewersAnnotation,
       presenterPolicy = lockSettingsProp.presenterPolicy
     )
+
+    // When lockSettings is in disabledFeatures the feature is fully off: ignore any lock
+    // restrictions coming from create params / server defaults so viewers stay unlocked.
+    val settings = if (liveMeeting.props.meetingProp.disabledFeatures.contains("lockSettings")) {
+      baseSettings.copy(
+        disableCam = false,
+        disableMic = false,
+        disablePrivChat = false,
+        disablePubChat = false,
+        disableNotes = false,
+        hideUserList = false,
+        lockOnJoin = false,
+        hideViewersCursor = false,
+        hideViewersAnnotation = false
+      )
+    } else {
+      baseSettings
+    }
 
     MeetingStatus2x.initializePermissions(liveMeeting.status)
     MeetingStatus2x.setPermissions(liveMeeting.status, settings)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
@@ -334,7 +334,10 @@ class MeetingActor(
   }
 
   private def initLockSettings(liveMeeting: LiveMeeting, lockSettingsProp: LockSettingsProps): Unit = {
-    val baseSettings = Permissions(
+    // lockSettingsProp is already neutralized at meeting-prop build time when lockSettings is in
+    // disabledFeatures (see BbbWebApiGWApp.createMeeting), so the runtime permissions stay in sync
+    // with the meeting_lockSettings DB row by construction.
+    val settings = Permissions(
       disableCam = lockSettingsProp.disableCam,
       disableMic = lockSettingsProp.disableMic,
       disablePrivChat = lockSettingsProp.disablePrivateChat,
@@ -347,24 +350,6 @@ class MeetingActor(
       hideViewersAnnotation = lockSettingsProp.hideViewersAnnotation,
       presenterPolicy = lockSettingsProp.presenterPolicy
     )
-
-    // When lockSettings is in disabledFeatures the feature is fully off: ignore any lock
-    // restrictions coming from create params / server defaults so viewers stay unlocked.
-    val settings = if (liveMeeting.props.meetingProp.disabledFeatures.contains("lockSettings")) {
-      baseSettings.copy(
-        disableCam = false,
-        disableMic = false,
-        disablePrivChat = false,
-        disablePubChat = false,
-        disableNotes = false,
-        hideUserList = false,
-        lockOnJoin = false,
-        hideViewersCursor = false,
-        hideViewersAnnotation = false
-      )
-    } else {
-      baseSettings
-    }
 
     MeetingStatus2x.initializePermissions(liveMeeting.status)
     MeetingStatus2x.setPermissions(liveMeeting.status, settings)

--- a/bbb-common-web/src/main/scala/org/bigbluebutton/api2/BbbWebApiGWApp.scala
+++ b/bbb-common-web/src/main/scala/org/bigbluebutton/api2/BbbWebApiGWApp.scala
@@ -182,6 +182,13 @@ class BbbWebApiGWApp(
 
     val disabledFeaturesAsVector: Vector[String] = disabledFeatures.asScala.toVector
 
+    // When lockSettings is in disabledFeatures the feature is fully off. Neutralize every lock
+    // restriction here, at the single point where the meeting props are built, so the DB row the
+    // client reads (v_meeting_lockSettings) and the akka runtime permissions share one source of
+    // truth. Overriding only akka's in-memory permissions later would leave the DB row populated
+    // from the raw create params, keeping hasActiveLockSetting true and the lock controls live.
+    val lockSettingsDisabled: Boolean = disabledFeaturesAsVector.contains("lockSettings")
+
     val sharedNotesInitialContentJsonVector: Vector[AnyRef] = sharedNotesInitialContentJson.asScala.toVector
     val meetingProp = MeetingProp(
       name = meetingName,
@@ -237,7 +244,7 @@ class BbbWebApiGWApp(
     val usersProp = UsersProp(
       maxUsers = maxUsers.intValue(),
       maxUserConcurrentAccesses = maxUserConcurrentAccesses,
-      webcamsOnlyForModerator = webcamsOnlyForModerator.booleanValue(),
+      webcamsOnlyForModerator = if (lockSettingsDisabled) false else webcamsOnlyForModerator.booleanValue(),
       multiUserWhiteboardEnabled = multiUserWhiteboardEnabled,
       userCameraCap = userCameraCap.intValue(),
       guestPolicy = guestPolicy, meetingLayout = meetingLayout, allowModsToUnmuteUsers = allowModsToUnmuteUsers.booleanValue(),
@@ -248,19 +255,37 @@ class BbbWebApiGWApp(
     )
     val metadataProp = MetadataProp(mapAsScalaMap(metadata).toMap)
 
-    val lockSettingsProps = LockSettingsProps(
-      disableCam = lockSettingsParams.disableCam.booleanValue(),
-      disableMic = lockSettingsParams.disableMic.booleanValue(),
-      disablePrivateChat = lockSettingsParams.disablePrivateChat.booleanValue(),
-      disablePublicChat = lockSettingsParams.disablePublicChat.booleanValue(),
-      disableNotes = lockSettingsParams.disableNotes.booleanValue(),
-      hideUserList = lockSettingsParams.hideUserList.booleanValue(),
-      lockOnJoin = lockSettingsParams.lockOnJoin.booleanValue(),
-      lockOnJoinConfigurable = lockSettingsParams.lockOnJoinConfigurable.booleanValue(),
-      hideViewersCursor = lockSettingsParams.hideViewersCursor.booleanValue(),
-      hideViewersAnnotation = lockSettingsParams.hideViewersAnnotation.booleanValue(),
-      presenterPolicy = lockSettingsParams.presenterPolicy
-    )
+    val lockSettingsProps = if (lockSettingsDisabled) {
+      // Feature disabled: every viewer lock restriction forced permissive and presenterPolicy
+      // reset to the default, so neither the stored row nor the runtime restrict viewers.
+      LockSettingsProps(
+        disableCam = false,
+        disableMic = false,
+        disablePrivateChat = false,
+        disablePublicChat = false,
+        disableNotes = false,
+        hideUserList = false,
+        lockOnJoin = false,
+        lockOnJoinConfigurable = lockSettingsParams.lockOnJoinConfigurable.booleanValue(),
+        hideViewersCursor = false,
+        hideViewersAnnotation = false,
+        presenterPolicy = "requireApproval"
+      )
+    } else {
+      LockSettingsProps(
+        disableCam = lockSettingsParams.disableCam.booleanValue(),
+        disableMic = lockSettingsParams.disableMic.booleanValue(),
+        disablePrivateChat = lockSettingsParams.disablePrivateChat.booleanValue(),
+        disablePublicChat = lockSettingsParams.disablePublicChat.booleanValue(),
+        disableNotes = lockSettingsParams.disableNotes.booleanValue(),
+        hideUserList = lockSettingsParams.hideUserList.booleanValue(),
+        lockOnJoin = lockSettingsParams.lockOnJoin.booleanValue(),
+        lockOnJoinConfigurable = lockSettingsParams.lockOnJoinConfigurable.booleanValue(),
+        hideViewersCursor = lockSettingsParams.hideViewersCursor.booleanValue(),
+        hideViewersAnnotation = lockSettingsParams.hideViewersAnnotation.booleanValue(),
+        presenterPolicy = lockSettingsParams.presenterPolicy
+      )
+    }
 
     val systemProps = SystemProps(
       loginUrl match {

--- a/bigbluebutton-html5/imports/ui/components/user-list/crowd-action-buttons/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/crowd-action-buttons/component.tsx
@@ -7,6 +7,7 @@ import { CrowdActionButtonsProps } from './types';
 import Styled from './styles';
 import LockViewersContainer from '../../lock-viewers/container';
 import { useModalRegistration } from '/imports/ui/core/singletons/modalController';
+import { useIsLockSettingsEnabled } from '/imports/ui/services/features';
 
 const intlMessages = defineMessages({
   muteAllExceptPresenterLabel: {
@@ -33,6 +34,7 @@ const CrowdActionButtons: React.FC<CrowdActionButtonsProps> = ({
   const intl = useIntl();
   const [setMuted] = useMutation(SET_MUTED);
   const lockViewersModal = useModalRegistration({ id: 'lockViewersModal', priority: 'low' });
+  const isLockSettingsEnabled = useIsLockSettingsEnabled();
 
   const muteAll = () => {
     setMuted({
@@ -80,7 +82,7 @@ const CrowdActionButtons: React.FC<CrowdActionButtonsProps> = ({
             onClick={muteAll}
           />
         </Styled.ActionButtonWrapper>
-        {!isBreakout && (
+        {!isBreakout && isLockSettingsEnabled && (
           <Styled.ActionButtonWrapper>
             <Styled.ActionButtonLabel>
               {intl.formatMessage(intlMessages.lockSettingsButtonLabel)}

--- a/bigbluebutton-html5/imports/ui/services/features/index.js
+++ b/bigbluebutton-html5/imports/ui/services/features/index.js
@@ -52,6 +52,10 @@ export function useIsBreakoutRoomsEnabled() {
   return useDisabledFeatures().indexOf('breakoutRooms') === -1;
 }
 
+export function useIsLockSettingsEnabled() {
+  return useDisabledFeatures().indexOf('lockSettings') === -1;
+}
+
 export function useIsVirtualBackgroundsEnabled() {
   return useDisabledFeatures().indexOf('virtualBackgrounds') === -1 && window.meetingClientSettings.public.virtualBackgrounds.enabled;
 }

--- a/bigbluebutton-tests/playwright/core/elements.ts
+++ b/bigbluebutton-tests/playwright/core/elements.ts
@@ -489,6 +489,7 @@ export const elements = {
   clearStatus: 'li[data-test="clearStatus"]',
 
   // Lock Viewers
+  muteAllUsers: 'button[data-test="muteAllUsers"]',
   lockViewersButton: 'button[data-test="lockViewersButton"]',
   unlockUserButton: 'li[data-test="unlockUserButton"]',
   applyLockSettings: 'button[data-test="applyLockSettings"]',

--- a/bigbluebutton-tests/playwright/parameters/constants.ts
+++ b/bigbluebutton-tests/playwright/parameters/constants.ts
@@ -92,6 +92,7 @@ export const constants = {
   externalVideosDisabled: 'disabledFeatures=externalVideos',
   learningDashboardDisabled: 'disabledFeatures=learningDashboard',
   pollsDisabled: 'disabledFeatures=polls',
+  lockSettingsDisabled: 'disabledFeatures=lockSettings',
   screenshareDisabled: 'disabledFeatures=screenshare',
   sharedNotesDisabled: 'disabledFeatures=sharedNotes',
   virtualBackgroundsDisabled: 'disabledFeatures=virtualBackgrounds',

--- a/bigbluebutton-tests/playwright/parameters/constants.ts
+++ b/bigbluebutton-tests/playwright/parameters/constants.ts
@@ -93,6 +93,7 @@ export const constants = {
   learningDashboardDisabled: 'disabledFeatures=learningDashboard',
   pollsDisabled: 'disabledFeatures=polls',
   lockSettingsDisabled: 'disabledFeatures=lockSettings',
+  lockSettingsDisabledWithChatLock: 'disabledFeatures=lockSettings&lockSettingsDisablePublicChat=true',
   screenshareDisabled: 'disabledFeatures=screenshare',
   sharedNotesDisabled: 'disabledFeatures=sharedNotes',
   virtualBackgroundsDisabled: 'disabledFeatures=virtualBackgrounds',

--- a/bigbluebutton-tests/playwright/parameters/disabledFeatures.ts
+++ b/bigbluebutton-tests/playwright/parameters/disabledFeatures.ts
@@ -75,6 +75,28 @@ export class DisabledFeatures extends MultiUsers {
     await this.modPage.wasRemoved(e.lockViewersButton, 'should not display the lock viewers button');
   }
 
+  async lockSettingsServerEnforcement() {
+    // The meeting was created with disabledFeatures=lockSettings AND
+    // lockSettingsDisablePublicChat=true. Because the feature is disabled, the lock must not
+    // be applied server-side and the moderator control must be hidden.
+    const isMuteAllVisible = await this.modPage.page.locator(e.muteAllUsers)
+      .isVisible({ timeout: ELEMENT_WAIT_TIME }).catch(() => false);
+    if (!isMuteAllVisible) {
+      await this.modPage.waitAndClick(e.usersListSidebarButton);
+    }
+    await this.modPage.wasRemoved(e.lockViewersButton, 'should not display the lock viewers button');
+
+    // The public-chat lock coming from the create parameter must be ignored, so the viewer
+    // can still send public chat messages.
+    await this.userPage.hasElementEnabled(e.chatBox, 'should keep the public chat enabled for the viewer');
+    await this.userPage.fill(e.chatBox, e.message);
+    await this.userPage.waitAndClick(e.sendButton);
+    await this.userPage.hasElement(
+      e.chatUserMessageText,
+      'viewer public chat message should be sent because the lock is not applied',
+    );
+  }
+
   async screenshare() {
     await this.modPage.wasRemoved(e.startScreenSharing, 'should not display the screenshare button');
   }

--- a/bigbluebutton-tests/playwright/parameters/disabledFeatures.ts
+++ b/bigbluebutton-tests/playwright/parameters/disabledFeatures.ts
@@ -1,6 +1,7 @@
-import { ELEMENT_WAIT_LONGER_TIME, ELEMENT_WAIT_TIME } from '../core/constants';
+import { ELEMENT_WAIT_LONGER_TIME } from '../core/constants';
 import { elements as e } from '../core/elements';
 import { MultiUsers } from '../user/multiusers';
+import { openUserListIfClosed } from '../user/util';
 
 export class DisabledFeatures extends MultiUsers {
   async breakoutRooms() {
@@ -62,12 +63,7 @@ export class DisabledFeatures extends MultiUsers {
   }
 
   async lockSettings() {
-    // Open the user list if it is not already showing the moderator crowd-action buttons.
-    const isMuteAllVisible = await this.modPage.page.locator(e.muteAllUsers)
-      .isVisible({ timeout: ELEMENT_WAIT_TIME }).catch(() => false);
-    if (!isMuteAllVisible) {
-      await this.modPage.waitAndClick(e.usersListSidebarButton);
-    }
+    await openUserListIfClosed(this.modPage);
     // The "mute all except presenter" button shares the moderator crowd-action area and is
     // not gated, so its presence confirms the area rendered while only the lock viewers
     // button is hidden by disabledFeatures=lockSettings.
@@ -79,12 +75,18 @@ export class DisabledFeatures extends MultiUsers {
     // The meeting was created with disabledFeatures=lockSettings AND
     // lockSettingsDisablePublicChat=true. Because the feature is disabled, the lock must not
     // be applied server-side and the moderator control must be hidden.
-    const isMuteAllVisible = await this.modPage.page.locator(e.muteAllUsers)
-      .isVisible({ timeout: ELEMENT_WAIT_TIME }).catch(() => false);
-    if (!isMuteAllVisible) {
-      await this.modPage.waitAndClick(e.usersListSidebarButton);
-    }
+    await openUserListIfClosed(this.modPage);
     await this.modPage.wasRemoved(e.lockViewersButton, 'should not display the lock viewers button');
+
+    // The per-user "Lock <user>" option is gated on hasActiveLockSetting. Neutralizing the
+    // lock create params at the source keeps that flag false, so the option must be absent for
+    // the viewer. This is the case that would surface a DB / in-memory divergence.
+    await this.modPage.page.locator(e.userListItem).filter({ hasText: this.userPage.username }).click();
+    await this.modPage.wasRemoved(
+      e.unlockUserButton,
+      'should not offer the per-user lock option when lockSettings is disabled',
+    );
+    await this.modPage.page.keyboard.press('Escape');
 
     // The public-chat lock coming from the create parameter must be ignored, so the viewer
     // can still send public chat messages.

--- a/bigbluebutton-tests/playwright/parameters/disabledFeatures.ts
+++ b/bigbluebutton-tests/playwright/parameters/disabledFeatures.ts
@@ -1,4 +1,4 @@
-import { ELEMENT_WAIT_LONGER_TIME } from '../core/constants';
+import { ELEMENT_WAIT_LONGER_TIME, ELEMENT_WAIT_TIME } from '../core/constants';
 import { elements as e } from '../core/elements';
 import { MultiUsers } from '../user/multiusers';
 
@@ -59,6 +59,20 @@ export class DisabledFeatures extends MultiUsers {
 
   async polls() {
     await this.modPage.wasRemoved(e.pollSidebarButton, 'should not display the poll sidebar button');
+  }
+
+  async lockSettings() {
+    // Open the user list if it is not already showing the moderator crowd-action buttons.
+    const isMuteAllVisible = await this.modPage.page.locator(e.muteAllUsers)
+      .isVisible({ timeout: ELEMENT_WAIT_TIME }).catch(() => false);
+    if (!isMuteAllVisible) {
+      await this.modPage.waitAndClick(e.usersListSidebarButton);
+    }
+    // The "mute all except presenter" button shares the moderator crowd-action area and is
+    // not gated, so its presence confirms the area rendered while only the lock viewers
+    // button is hidden by disabledFeatures=lockSettings.
+    await this.modPage.hasElement(e.muteAllUsers, 'should display the moderator crowd action buttons');
+    await this.modPage.wasRemoved(e.lockViewersButton, 'should not display the lock viewers button');
   }
 
   async screenshare() {

--- a/bigbluebutton-tests/playwright/parameters/parameters.spec.ts
+++ b/bigbluebutton-tests/playwright/parameters/parameters.spec.ts
@@ -303,6 +303,12 @@ test.describe.parallel('Create Parameters', { tag: '@ci' }, () => {
         await disabledFeatures.initModPage(page, { createParameter: c.lockSettingsDisabled, testInfo });
         await disabledFeatures.lockSettings();
       });
+      test('Lock Settings (server-side enforcement)', async ({ browser, context, page }, testInfo) => {
+        const disabledFeatures = new DisabledFeatures(browser, context);
+        await disabledFeatures.initModPage(page, { createParameter: c.lockSettingsDisabledWithChatLock, testInfo });
+        await disabledFeatures.initUserPage(context, { testInfo });
+        await disabledFeatures.lockSettingsServerEnforcement();
+      });
     });
 
     test.describe.serial(() => {

--- a/bigbluebutton-tests/playwright/parameters/parameters.spec.ts
+++ b/bigbluebutton-tests/playwright/parameters/parameters.spec.ts
@@ -298,6 +298,14 @@ test.describe.parallel('Create Parameters', { tag: '@ci' }, () => {
     });
 
     test.describe.serial(() => {
+      test('Lock Settings', async ({ browser, context, page }, testInfo) => {
+        const disabledFeatures = new DisabledFeatures(browser, context);
+        await disabledFeatures.initModPage(page, { createParameter: c.lockSettingsDisabled, testInfo });
+        await disabledFeatures.lockSettings();
+      });
+    });
+
+    test.describe.serial(() => {
       test('Screenshare', async ({ browser, context, page }, testInfo) => {
         const disabledFeatures = new DisabledFeatures(browser, context);
         await disabledFeatures.initModPage(page, { createParameter: c.screenshareDisabled, testInfo });

--- a/bigbluebutton-tests/playwright/user/util.ts
+++ b/bigbluebutton-tests/playwright/user/util.ts
@@ -12,6 +12,20 @@ export async function openLockViewers(testPage: Page) {
   await testPage.waitAndClick(e.lockViewersButton);
 }
 
+export async function openUserListIfClosed(testPage: Page) {
+  // Open the user list panel if it is collapsed, so the moderator crowd-action area is reachable.
+  // Note: locator.isVisible() ignores its `timeout` option and returns the current snapshot, which
+  // is racy right after join; wait for the panel state instead of probing it synchronously.
+  const isPanelOpen = await testPage.page.locator(e.userListPanel)
+    .waitFor({ state: 'visible', timeout: ELEMENT_WAIT_TIME })
+    .then(() => true)
+    .catch(() => false);
+  if (!isPanelOpen) {
+    await testPage.waitAndClick(e.usersListSidebarButton);
+    await testPage.hasElement(e.userListPanel, 'should open the user list panel');
+  }
+}
+
 export async function setGuestPolicyOption(testPage: Page, option: string) {
   await openLockViewers(testPage);
   await testPage.waitAndClick(e.guestPolicyTab);

--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -558,7 +558,8 @@ endWhenNoModeratorDelayInMinutes=1
 # breakoutRooms, importSharedNotesFromBreakoutRooms, importPresentationWithAnnotationsFromBreakoutRooms,
 # presentation, downloadPresentationWithAnnotations, downloadPresentationOriginalFile, downloadPresentationConvertedToPdf,
 # learningDashboard, learningDashboardDownloadSessionData, snapshotOfCurrentSlide,
-# virtualBackgrounds, customVirtualBackgrounds, raiseHand, userReactions, chatEmojiPicker, quizzes
+# virtualBackgrounds, customVirtualBackgrounds, raiseHand, userReactions, chatEmojiPicker, quizzes,
+# lockSettings
 disabledFeatures=
 
 # Type of shared notes:

--- a/docs/docs/data/create.tsx
+++ b/docs/docs/data/create.tsx
@@ -548,6 +548,9 @@ const createEndpointTableData = [
             <li>
               <code className="language-plaintext highlighter-rouge">multiFunctionalMode</code> - <b>Multi-Functional Mode - multiple sidebars</b>
             </li>
+            <li>
+              <code className="language-plaintext highlighter-rouge">lockSettings</code> - <b>Lock viewers settings (added in BigBlueButton 4.0)</b> - hides the "Lock viewers" moderator control; all viewer restrictions remain unlocked
+            </li>
           </ul>
         </>
     ),

--- a/docs/docs/data/create.tsx
+++ b/docs/docs/data/create.tsx
@@ -549,7 +549,7 @@ const createEndpointTableData = [
               <code className="language-plaintext highlighter-rouge">multiFunctionalMode</code> - <b>Multi-Functional Mode - multiple sidebars</b>
             </li>
             <li>
-              <code className="language-plaintext highlighter-rouge">lockSettings</code> - <b>Lock viewers settings (added in BigBlueButton 4.0)</b> - hides the "Lock viewers" moderator control; all viewer restrictions remain unlocked
+              <code className="language-plaintext highlighter-rouge">lockSettings</code> - <b>Lock viewers settings (added in BigBlueButton 4.0)</b> - removes the "Lock viewers" moderator control and disables lock enforcement, so all viewer restrictions stay unlocked for the meeting (lock create parameters and server defaults are ignored)
             </li>
           </ul>
         </>

--- a/docs/docs/development/api.md
+++ b/docs/docs/development/api.md
@@ -132,7 +132,7 @@ Updated in 4.0:
 
 - **create**
   - **Added parameters:** `requireUserConsentBeforeUnmuting` (only relevant when `allowModsToUnmuteUsers=true`; when `true`, the user is shown a consent dialog before a moderator can unmute them), `lockSettingsPresenterPolicy` (controls the "Request to Present" policy; one of `moderatorOnly`, `requireApproval` (default), `freeForAll`).
-  - **Added options:** Parameter `disabledFeatures` supports new options: `multiFunctionalMode` (the auxiliary/dual sidebar panel), `pinChatMessage`, and `lockSettings` (removes the "Lock viewers" moderator control and disables lock enforcement, so viewer restrictions stay unlocked even if lock create parameters or server defaults are set).
+  - **Added options:** Parameter `disabledFeatures` supports new options: `multiFunctionalMode` (the auxiliary/dual sidebar panel), `pinChatMessage`, and `lockSettings` .
   - **Changed:** Parameter `meetingLayout` default is now `UNIFIED_LAYOUT`. **Removed:** `meetingLayout` no longer supports `CUSTOM_LAYOUT`, `SMART_LAYOUT`, `PRESENTATION_FOCUS`, `VIDEO_FOCUS`. The remaining non-default options targeting hybrid/niche scenarios are `CAMERAS_ONLY`, `PARTICIPANTS_CHAT_ONLY`, `PRESENTATION_ONLY`, `MEDIA_ONLY`.
   - **Removed option:** `layouts` is no longer a valid `disabledFeatures` value (the layout selection UI was removed).
 - **join**

--- a/docs/docs/development/api.md
+++ b/docs/docs/development/api.md
@@ -132,7 +132,7 @@ Updated in 4.0:
 
 - **create**
   - **Added parameters:** `requireUserConsentBeforeUnmuting` (only relevant when `allowModsToUnmuteUsers=true`; when `true`, the user is shown a consent dialog before a moderator can unmute them), `lockSettingsPresenterPolicy` (controls the "Request to Present" policy; one of `moderatorOnly`, `requireApproval` (default), `freeForAll`).
-  - **Added options:** Parameter `disabledFeatures` supports new options: `multiFunctionalMode` (the auxiliary/dual sidebar panel) and `pinChatMessage`.
+  - **Added options:** Parameter `disabledFeatures` supports new options: `multiFunctionalMode` (the auxiliary/dual sidebar panel), `pinChatMessage`, and `lockSettings` (hides the "Lock viewers" moderator control; viewer restrictions stay unlocked).
   - **Changed:** Parameter `meetingLayout` default is now `UNIFIED_LAYOUT`. **Removed:** `meetingLayout` no longer supports `CUSTOM_LAYOUT`, `SMART_LAYOUT`, `PRESENTATION_FOCUS`, `VIDEO_FOCUS`. The remaining non-default options targeting hybrid/niche scenarios are `CAMERAS_ONLY`, `PARTICIPANTS_CHAT_ONLY`, `PRESENTATION_ONLY`, `MEDIA_ONLY`.
   - **Removed option:** `layouts` is no longer a valid `disabledFeatures` value (the layout selection UI was removed).
 - **join**

--- a/docs/docs/development/api.md
+++ b/docs/docs/development/api.md
@@ -132,7 +132,7 @@ Updated in 4.0:
 
 - **create**
   - **Added parameters:** `requireUserConsentBeforeUnmuting` (only relevant when `allowModsToUnmuteUsers=true`; when `true`, the user is shown a consent dialog before a moderator can unmute them), `lockSettingsPresenterPolicy` (controls the "Request to Present" policy; one of `moderatorOnly`, `requireApproval` (default), `freeForAll`).
-  - **Added options:** Parameter `disabledFeatures` supports new options: `multiFunctionalMode` (the auxiliary/dual sidebar panel), `pinChatMessage`, and `lockSettings` (hides the "Lock viewers" moderator control; viewer restrictions stay unlocked).
+  - **Added options:** Parameter `disabledFeatures` supports new options: `multiFunctionalMode` (the auxiliary/dual sidebar panel), `pinChatMessage`, and `lockSettings` (removes the "Lock viewers" moderator control and disables lock enforcement, so viewer restrictions stay unlocked even if lock create parameters or server defaults are set).
   - **Changed:** Parameter `meetingLayout` default is now `UNIFIED_LAYOUT`. **Removed:** `meetingLayout` no longer supports `CUSTOM_LAYOUT`, `SMART_LAYOUT`, `PRESENTATION_FOCUS`, `VIDEO_FOCUS`. The remaining non-default options targeting hybrid/niche scenarios are `CAMERAS_ONLY`, `PARTICIPANTS_CHAT_ONLY`, `PRESENTATION_ONLY`, `MEDIA_ONLY`.
   - **Removed option:** `layouts` is no longer a valid `disabledFeatures` value (the layout selection UI was removed).
 - **join**

--- a/docs/docs/new-features.md
+++ b/docs/docs/new-features.md
@@ -78,7 +78,7 @@ A new **Multi-Functional Mode** adds an auxiliary sidebar content panel, allowin
 
 #### Disable lock settings per meeting
 
-Lock settings can now be turned off for a meeting with the new `lockSettings` value of `disabledFeatures`. When listed, the "Lock viewers" control is removed from the moderator's user-list options, and all viewer restrictions stay unlocked for that meeting.
+Lock settings can now be turned off for a meeting with the new `lockSettings` value of `disabledFeatures`. When listed, the "Lock viewers" control is removed from the moderator's user-list options and lock enforcement is turned off server-side, so all viewer restrictions stay unlocked for that meeting even if lock create parameters or server defaults are set.
 
 <!-- ### Analytics -->
 
@@ -216,7 +216,7 @@ _None._
 - `defaultMeetingLayout` default changed from `CUSTOM_LAYOUT` to `UNIFIED_LAYOUT`. Accepted values are now `UNIFIED_LAYOUT` (default), plus the hybrid/niche options `CAMERAS_ONLY`, `PARTICIPANTS_CHAT_ONLY`, and `PRESENTATION_ONLY`. The previous values `CUSTOM_LAYOUT`, `SMART_LAYOUT`, `PRESENTATION_FOCUS`, and `VIDEO_FOCUS` are no longer accepted.
 - `html5PluginSdkVersion` bumped from `0.0.99` to `0.1.17`.
 - `disabledFeatures` accepts a new value: `pinChatMessage` (alongside the existing chat-related options).
-- `disabledFeatures` accepts a new value: `lockSettings` (removes the "Lock viewers" moderator control and leaves all viewer restrictions unlocked).
+- `disabledFeatures` accepts a new value: `lockSettings` (removes the "Lock viewers" moderator control and disables lock enforcement, leaving all viewer restrictions unlocked).
 
 #### Added
 

--- a/docs/docs/new-features.md
+++ b/docs/docs/new-features.md
@@ -76,6 +76,10 @@ When `allowModsToUnmuteUsers` is enabled, BigBlueButton 4.0 can optionally ask t
 
 A new **Multi-Functional Mode** adds an auxiliary sidebar content panel, allowing a second panel to be open alongside the primary one (for example, chat and the user list at the same time). It is disabled by default and enabled with `public.multiFunctionalMode.enabled` in `settings.yml`, and it can be disabled per meeting with the `multiFunctionalMode` value of `disabledFeatures`.
 
+#### Disable lock settings per meeting
+
+Lock settings can now be turned off for a meeting with the new `lockSettings` value of `disabledFeatures`. When listed, the "Lock viewers" control is removed from the moderator's user-list options, and all viewer restrictions stay unlocked for that meeting.
+
 <!-- ### Analytics -->
 
 ### Behind the scenes
@@ -212,6 +216,7 @@ _None._
 - `defaultMeetingLayout` default changed from `CUSTOM_LAYOUT` to `UNIFIED_LAYOUT`. Accepted values are now `UNIFIED_LAYOUT` (default), plus the hybrid/niche options `CAMERAS_ONLY`, `PARTICIPANTS_CHAT_ONLY`, and `PRESENTATION_ONLY`. The previous values `CUSTOM_LAYOUT`, `SMART_LAYOUT`, `PRESENTATION_FOCUS`, and `VIDEO_FOCUS` are no longer accepted.
 - `html5PluginSdkVersion` bumped from `0.0.99` to `0.1.17`.
 - `disabledFeatures` accepts a new value: `pinChatMessage` (alongside the existing chat-related options).
+- `disabledFeatures` accepts a new value: `lockSettings` (removes the "Lock viewers" moderator control and leaves all viewer restrictions unlocked).
 
 #### Added
 


### PR DESCRIPTION
# What & why

Closes bigbluebutton/bigbluebutton#25143.

`disabledFeatures` lets an integrator turn off individual features per meeting (via the `/create` API or server-wide in `bbb.properties`). This PR adds a new value, `lockSettings`.

When `lockSettings` is disabled, the lock viewers feature is turned off both in the UI and server-side:

- the moderator's **Lock viewers** control is removed from the user-list options, and
- lock enforcement is disabled — viewer lock restrictions are forced to their permissive defaults, so locks coming from lock create parameters (e.g. `lockSettingsDisableCam`) or server defaults are not applied, and runtime lock-settings changes are ignored.

This makes `lockSettings` a true functional disable, consistent with the other `disabledFeatures` values that already enforce server-side (`breakoutRooms`, `polls`, `screenshare`, `presentation`, `raiseHand`, `timer`, ...), rather than a UI-only gate.

# Changes

**Client**
- `bigbluebutton-html5/imports/ui/services/features/index.js` — new `useIsLockSettingsEnabled()` hook.
- `bigbluebutton-html5/imports/ui/components/user-list/crowd-action-buttons/component.tsx` — the **Lock viewers** button is rendered only when lock settings are enabled.

**Server (akka-bbb-apps)**
- `MeetingActor.scala` (`initLockSettings`) — when `lockSettings` is disabled, force all viewer lock restrictions (`disableCam/Mic/PrivChat/PubChat/Notes`, `hideUserList`, `hideViewersCursor/Annotation`, `lockOnJoin`) to permissive, so create-param / server-default locks are not applied.
- `ChangeLockSettingsInMeetingCmdMsgHdlr.scala` (`handleSetLockSettings`) — ignore runtime lock-settings changes when the feature is disabled, so a non-standard client cannot re-enable locks. With meeting permissions forced permissive, per-user locks become inert.

**Automated test**
- `bigbluebutton-tests/playwright/parameters/disabledFeatures.ts` — new `lockSettings()` check: opens the user list, asserts the (ungated) "mute all" button is present while the lock viewers button is removed.
- `parameters.spec.ts` + `constants.ts` — wire the `Lock Settings` test under **Disabled Features**.
- `core/elements.ts` — `muteAllUsers` selector (positive control).

**Docs**
- `docs/docs/data/create.tsx`, `docs/docs/development/api.md`, `docs/docs/new-features.md` — document `lockSettings` (added in 4.0): removes the control and disables lock enforcement.
- `bigbluebutton-web/grails-app/conf/bigbluebutton.properties` — inline comment of valid `disabledFeatures` options.

# How to test

1. Create a meeting with `disabledFeatures=lockSettings` (optionally also pass `lockSettingsDisableCam=true`).
2. Join as a moderator and open the user list: the **Lock viewers** button is gone (the "Mute all" button remains).
3. Join as a viewer: the camera (and any other lock that would have come from create params/defaults) is **not** locked.
4. Without the flag, the **Lock viewers** control and lock enforcement behave as usual.

# Test coverage

`bigbluebutton-tests/playwright` → `Create Parameters › Disabled Features › Lock Settings`, validated on a BBB 4.0 (`v4.0.x-develop`) instance:

- **Before the fix:** `1 failed` — `should not display the lock viewers button` (the button stays visible).
- **After the fix:** `2 passed` (setup + the new test).
- **No regression:** the existing `User › Manage › Lock viewers › Lock Send public chat messages` test passes — the lock viewers control still works normally when the feature is not disabled.

There are two `Disabled Features › Lock Settings` tests:

1. **UI gate** — `disabledFeatures=lockSettings`: the lock viewers button is removed.
2. **Server enforcement** — `disabledFeatures=lockSettings` **and** `lockSettingsDisablePublicChat=true`: the viewer can still send public chat (the lock is not applied) and the button is hidden. This was validated fail-before / pass-after on a `v4.0.x-develop` instance (without the server change the viewer's chat was locked; with it the viewer chats freely).

**Evidence**

UI gate — lock viewers button, before vs after with `disabledFeatures=lockSettings`:

![ui before vs after](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-06-01/3dbef9ad-b994-4608-937f-6dfb0581cb2a/comparison.png)

Server enforcement — with `disabledFeatures=lockSettings` + `lockSettingsDisablePublicChat=true`, the viewer's public chat is not locked:

![server before vs after](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-06-01/568d6521-5121-475b-9de4-7ed929c12509/lockSettings-server-enforcement.png)

- UI before/after videos: [before.mp4](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-06-01/a4ea8cff-1f5a-49d8-b2e1-c87e1bcc6e3e/before.mp4) | [after.mp4](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-06-01/1371f14f-4436-42da-a7fe-9497eb1147af/after.mp4)
