### PR TITLE
fix(presentation): authenticate manage-presentations thumbnail URL

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/media-area/media-sharing/presentation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/media-area/media-sharing/presentation/component.jsx
@@ -10,6 +10,7 @@ import Styled from './styles';
 import PresentationDownloadDropdown from './presentation-download-dropdown/component';
 import { getSettingsSingletonInstance } from '/imports/ui/services/settings';
 import Session from '/imports/ui/services/storage/in-memory';
+import Auth from '/imports/ui/services/auth';
 import ModalStyled from '../styles';
 
 const { isMobile } = deviceInfo;
@@ -578,7 +579,7 @@ class PresentationUploader extends Component {
           }}
           aria-label={`${item.name}`}
         >
-          <img src={firstPageThumbnailUrl} alt={item.name} />
+          <img src={Auth.authenticateURL(firstPageThumbnailUrl)} alt={item.name} />
         </Styled.PresentationThumbnail>
         <Styled.PresentationItemBottomContainer>
           <Styled.PresentationItemName data-test="presentationName">

--- a/bigbluebutton-tests/playwright/presentation/presentation.spec.ts
+++ b/bigbluebutton-tests/playwright/presentation/presentation.spec.ts
@@ -174,6 +174,13 @@ test.describe.parallel('Presentation', { tag: '@ci' }, () => {
       await presentation.removeAllPresentation();
     });
 
+    test('Presentation thumbnail loads', async ({ browser, context, page }, testInfo) => {
+      linkIssue(25163);
+      const presentation = new Presentation(browser, context);
+      await presentation.initModPage(page, { testInfo });
+      await presentation.presentationThumbnailLoads();
+    });
+
     test('Upload and remove all presentations', { tag: '@flaky' }, async ({ browser, context, page }, testInfo) => {
       // duplicate toast notification displayed
       linkIssue(24056);

--- a/bigbluebutton-tests/playwright/presentation/presentation.ts
+++ b/bigbluebutton-tests/playwright/presentation/presentation.ts
@@ -543,6 +543,38 @@ export class Presentation extends MultiUsers {
     );
   }
 
+  async presentationThumbnailLoads() {
+    await this.modPage.waitForSelector(e.whiteboard, ELEMENT_WAIT_LONGER_TIME);
+    await this.modPage.waitAndClick(e.mediaAreaButton);
+    await this.modPage.waitAndClick(e.managePresentations);
+    await this.modPage.hasElement(
+      e.presentationItem,
+      'should display the presentation item in the manage presentations list',
+    );
+
+    const thumbnail = this.modPage.page.locator(e.presentationThumbnails).first().locator('img');
+
+    // The thumbnail request is authorized only when the client appends the session
+    // token to the URL (the server returns 401 otherwise). Without the token the
+    // image fails to load and naturalWidth stays 0.
+    await expect(thumbnail, 'should append the session token to the thumbnail URL').toHaveAttribute(
+      'src',
+      /sessionToken=/,
+      { timeout: ELEMENT_WAIT_TIME },
+    );
+
+    await expect
+      .poll(
+        async () =>
+          thumbnail.evaluate((img) => (img as HTMLImageElement).complete && (img as HTMLImageElement).naturalWidth > 0),
+        {
+          message: 'should load the presentation thumbnail image (no 401 Unauthorized)',
+          timeout: ELEMENT_WAIT_LONGER_TIME,
+        },
+      )
+      .toBe(true);
+  }
+
   async uploadAndRemoveAllPresentations() {
     await uploadSinglePresentation(this.modPage, e.uploadPresentationFileName);
     await this.modPage.waitForSelector(e.whiteboard, ELEMENT_WAIT_LONGER_TIME);


### PR DESCRIPTION
## What and why

On 4.0 the presentation thumbnails in the "Manage presentations" panel fail to load: they render as broken images while the browser console reports `401 (Unauthorized)` for `/bigbluebutton/presentation/.../thumbnail/<page>` requests.

Reported in bigbluebutton/bigbluebutton#25163.

### Root cause

Presentation resource URLs (svg, png, thumbnail) are built server-side with only a `pageToken` query param (`MsgBuilder.generatePresentationPage`). Since #25020 ("Require SessionToken and PageToken on Presentation Page Requests") the authorization endpoint also requires a `sessionToken` in the query string and returns `401` before it even checks the `pageToken`:

```groovy
// PresentationController.checkPresentationAuthorization
def sessionToken = ParamsUtil.getSessionToken(uri)
...
if (userSession == null || isSessionTokenInvalid) {
  response.setStatus(401)   // returned before pageToken is validated
  ...
}
```

The client is responsible for appending the session token before fetching. The slide path already does this through `Auth.authenticateURL()` (`presentation/container.jsx`), which is why slides render. The media-sharing thumbnail used the raw URL straight from GraphQL:

```jsx
<img src={firstPageThumbnailUrl} alt={item.name} />
```

so the request reached the server without a `sessionToken` and was rejected with `401`. The thumbnail `<img>` predates #25020 (added 2025-07), so the auth-hardening turned it into a regression. A repo-wide search confirms this is the only presentation-thumbnail `<img>` consumer in the client.

## The fix

Authenticate the thumbnail URL the same way the slide path does, reusing the existing helper:

```jsx
<img src={Auth.authenticateURL(firstPageThumbnailUrl)} alt={item.name} />
```

One client file, no backend change. `Auth.authenticateURL` is idempotent (it will not duplicate an existing `sessionToken`), and the surrounding `if (isProcessing || !firstPageThumbnailUrl) return null;` guard guarantees a non-empty URL.

## Tests

Adds a Playwright test (`Presentation thumbnail loads`, in `bigbluebutton-tests/playwright/presentation`) that opens the Manage presentations panel and asserts the thumbnail URL carries the `sessionToken` and the image actually loads (`naturalWidth > 0`, i.e. not a 401), following the existing Manage-test conventions.

## Validation on a live BBB 4.0.0-beta.3 environment

Same container and server, the only change between the two runs is this one-line client fix (built from source):

| | Before (unpatched client) | After (fix) |
|---|---|---|
| Thumbnail request | **401 Unauthorized** | **200 OK** |
| Thumbnail URL | `?pageToken=...` only | `?pageToken=...&sessionToken=...` |
| Rendered image | broken (`naturalWidth = 0`) | loads (`naturalWidth = 150`) |
| Console 401s | 1 | 0 |

Preview below - click the GIF to open the MP4 (higher quality, with controls).

**Before** (thumbnail 401, broken):

[![Before - thumbnail 401 broken](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-06-04/0d37c33c-6155-4488-b9c3-a50fa4b691b3/before.gif)](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-06-04/13991253-7ed0-4726-95a3-c584c8a2be92/before.mp4)

![Before screenshot](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-06-04/9b71c389-bbc3-4766-887c-7a43f32f65b7/before-screenshot.png)

**After** (thumbnail 200, loads):

[![After - thumbnail loads](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-06-04/3cd48fbf-a93d-422f-a35b-c0d369237b7f/after.gif)](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-06-04/4344a48a-dab5-4dbf-9832-e95f51ee4c2c/after.mp4)

![After screenshot](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-06-04/62fbb679-259a-4684-bf8c-787dc600fbb4/after-screenshot.png)

Fixes bigbluebutton/bigbluebutton#25163
