### PR TITLE
fix: Unified Layout: tile count plus aggregated users does not match total participant count (3.0 backport)

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/component.tsx
@@ -85,6 +85,7 @@ interface VideoListProps {
   onVideoItemMount: (stream: string, video: HTMLVideoElement) => void;
   onVideoItemUnmount: (stream: string) => void;
   onVirtualBgDrop: (stream: string, type: string, name: string, data: string) => Promise<unknown>;
+  gridSize: number;
 }
 
 interface VideoListState {
@@ -227,11 +228,15 @@ class VideoList extends Component<VideoListProps, VideoListState> {
       streams,
       cameraDock,
       layoutContextDispatch,
+      isGridEnabled,
+      gridSize,
     } = this.props;
     const visibleStreams = streams.filter(
       (item) => item.type === VIDEO_TYPES.GRID || !('render' in item) || item.render !== false,
     );
-    let numItems = visibleStreams.length;
+    let numItems = isGridEnabled
+      ? Math.min(gridSize, visibleStreams.length)
+      : visibleStreams.length;
 
     if (numItems < 1 || !this.canvas || !this.grid) {
       return;
@@ -365,6 +370,7 @@ class VideoList extends Component<VideoListProps, VideoListState> {
       pluginUserCameraHelperPerPosition,
       isGridEnabled,
       overflowCount,
+      gridSize,
     } = this.props;
     const numOfStreams = streams.filter(
       (item) => item.type === VIDEO_TYPES.GRID || !('render' in item) || item.render !== false,
@@ -372,17 +378,10 @@ class VideoList extends Component<VideoListProps, VideoListState> {
 
     const shouldShowOverflowTile = isGridEnabled && overflowCount > 0;
 
-    let streamsToRender = streams;
-    if (shouldShowOverflowTile) {
-      const lastGridUserIndex = streams.map((s, idx) => ({ s, idx }))
-        .reverse()
-        .find(({ s }) => s.type === VIDEO_TYPES.GRID)?.idx;
-
-      if (lastGridUserIndex !== undefined) {
-        // remove the last grid user to replace it with the overflow tile
-        streamsToRender = streams.filter((_, idx) => idx !== lastGridUserIndex);
-      }
-    }
+    const streamsToHide = (numOfStreams - gridSize + 1) * -1;
+    const streamsToRender = shouldShowOverflowTile && streamsToHide < 0
+      ? streams.slice(0, streamsToHide)
+      : streams;
 
     const videoItems = streamsToRender.map((item) => {
       const { userId, name } = item;

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/container.tsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/container.tsx
@@ -6,7 +6,7 @@ import React, {
 import { UserCameraHelperButton, UserCameraHelperInterface, UserCameraHelperItemPosition } from 'bigbluebutton-html-plugin-sdk';
 import VideoList from '/imports/ui/components/video-provider/video-list/component';
 import { layoutSelect, layoutDispatch } from '/imports/ui/components/layout/context';
-import { useNumberOfPages } from '/imports/ui/components/video-provider/hooks';
+import { useNumberOfPages, useGridSize } from '/imports/ui/components/video-provider/hooks';
 import { VideoItem } from '/imports/ui/components/video-provider/types';
 import { Layout, Output } from '/imports/ui/components/layout/layoutTypes';
 import { PluginsContext } from '/imports/ui/components/components-data/plugin-context/context';
@@ -45,6 +45,7 @@ const VideoListContainer: React.FC<VideoListContainerProps> = (props) => {
     onVirtualBgDrop,
   } = props;
   const numberOfPages = useNumberOfPages();
+  const gridSize = useGridSize();
 
   const { pluginsExtensibleAreasAggregatedState } = useContext(PluginsContext);
 
@@ -118,6 +119,7 @@ const VideoListContainer: React.FC<VideoListContainerProps> = (props) => {
           onVideoItemMount={onVideoItemMount}
           onVideoItemUnmount={onVideoItemUnmount}
           onVirtualBgDrop={onVirtualBgDrop}
+          gridSize={gridSize}
         />
       )
   );


### PR DESCRIPTION
### What does this PR do?

Backport of bigbluebutton/bigbluebutton#25103 to the 3.0 line (`v3.0.x-develop`).

Fixes the unified-layout grid tile/overflow calculation. In the unified layout, when the presentation is minimized, participants are shown as tiles and any excess is aggregated into a single "+X" tile. The sum of visible tiles plus the aggregated count did not match the total number of participants, and toggling a camera added/removed a tile instead of transitioning it.

### Root cause

In `video-list/component.tsx`:
1. `numItems` (which dimensions the grid) was never capped by `gridSize`.
2. To make room for the overflow tile, the code removed only the **last grid user**, regardless of how many users were overflowing. Since `overflowCount` is computed as `(userCount - gridSize) + 1` (in `useGridUsers`), freeing a single slot made the math wrong whenever more than one user overflowed - most visibly when the number of shared cameras exceeds `gridSize` (then there is no GRID-type user to remove and every camera tile is rendered alongside the "+X" tile).

### Fix (identical to bigbluebutton/bigbluebutton#25103)

- Cap `numItems` to `min(gridSize, visibleStreams.length)` when the grid is enabled.
- Compute the rendered streams by slicing off exactly `numOfStreams - gridSize + 1` items instead of dropping the last grid user.

`useGridSize` already exists on 3.0, so the change is a 1:1 port (+14/-13, 2 files).

### How to test

1. Set `public.kurento.pagination.desktopGridSizes` low (e.g. `moderator: 3`, `viewer: 3`).
2. Join the unified layout, add more camera publishers than `gridSize`, minimize the presentation.
3. Count the visible tiles and add the number on the "+X" aggregated tile - it must equal the total number of participants.

### Evidence

Reproduced from source on a BBB 3.0 environment (`gridSize = 3`, 5 camera publishers, unified layout, presentation minimized):

- __Before (bug):__ 5 camera tiles + "__+3 users__" tile = the grid presents 8 while only 5 users are in the meeting.
- __After (fix):__ visible tiles + the "+X" tile == 5 (total participants).

__Before (bug)__ - click the image to open the MP4 demo:

[![Before fix - grid shows 5 tiles + +3 users = 8 for 5 participants](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-06-04/43f1f65a-8c9d-4e7b-9cd6-dc957c374619/grid-before.png)](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-06-04/42aa8ec2-8c48-4413-b461-71d66e50e62c/grid-25103-before-small.mp4)

__After (fix)__ - click the image to open the MP4 demo:

[![After fix - grid shows 2 tiles + +3 users = 5 participants](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-06-04/818bbc2b-728c-4045-9acf-8c67f53ed221/grid-after.png)](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-06-04/533c69bf-a598-41c5-a48d-cb7eb447b04b/grid-25103-after-small.mp4)

Automated behavioral check (Playwright, drives the real client): asserts `visibleTiles + overflowCount === totalParticipants`.
- Before fix: `totalUsers=5 visibleTiles=5 overflowCount=3 sum=8 invariant_holds=false`
- After fix: `totalUsers=5 visibleTiles=2 overflowCount=3 sum=5 invariant_holds=true`

### Notes

The upstream PR bigbluebutton/bigbluebutton#25103 shipped without unit tests; `bigbluebutton-html5` has no unit-test harness. Validation here is behavioral (before/after on a running 3.0 build).
