### PR TITLE
fix: Unified Layout tile count plus aggregated users does not match total participant count (3.0 backport)

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/component.tsx
@@ -85,6 +85,7 @@ interface VideoListProps {
   onVideoItemMount: (stream: string, video: HTMLVideoElement) => void;
   onVideoItemUnmount: (stream: string) => void;
   onVirtualBgDrop: (stream: string, type: string, name: string, data: string) => Promise<unknown>;
+  gridSize: number;
 }
 
 interface VideoListState {
@@ -227,11 +228,15 @@ class VideoList extends Component<VideoListProps, VideoListState> {
       streams,
       cameraDock,
       layoutContextDispatch,
+      isGridEnabled,
+      gridSize,
     } = this.props;
     const visibleStreams = streams.filter(
       (item) => item.type === VIDEO_TYPES.GRID || !('render' in item) || item.render !== false,
     );
-    let numItems = visibleStreams.length;
+    let numItems = isGridEnabled
+      ? Math.min(gridSize, visibleStreams.length)
+      : visibleStreams.length;
 
     if (numItems < 1 || !this.canvas || !this.grid) {
       return;
@@ -365,6 +370,7 @@ class VideoList extends Component<VideoListProps, VideoListState> {
       pluginUserCameraHelperPerPosition,
       isGridEnabled,
       overflowCount,
+      gridSize,
     } = this.props;
     const numOfStreams = streams.filter(
       (item) => item.type === VIDEO_TYPES.GRID || !('render' in item) || item.render !== false,
@@ -372,17 +378,10 @@ class VideoList extends Component<VideoListProps, VideoListState> {
 
     const shouldShowOverflowTile = isGridEnabled && overflowCount > 0;
 
-    let streamsToRender = streams;
-    if (shouldShowOverflowTile) {
-      const lastGridUserIndex = streams.map((s, idx) => ({ s, idx }))
-        .reverse()
-        .find(({ s }) => s.type === VIDEO_TYPES.GRID)?.idx;
-
-      if (lastGridUserIndex !== undefined) {
-        // remove the last grid user to replace it with the overflow tile
-        streamsToRender = streams.filter((_, idx) => idx !== lastGridUserIndex);
-      }
-    }
+    const streamsToHide = (numOfStreams - gridSize + 1) * -1;
+    const streamsToRender = shouldShowOverflowTile && streamsToHide < 0
+      ? streams.slice(0, streamsToHide)
+      : streams;
 
     const videoItems = streamsToRender.map((item) => {
       const { userId, name } = item;

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/container.tsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/container.tsx
@@ -6,7 +6,7 @@ import React, {
 import { UserCameraHelperButton, UserCameraHelperInterface, UserCameraHelperItemPosition } from 'bigbluebutton-html-plugin-sdk';
 import VideoList from '/imports/ui/components/video-provider/video-list/component';
 import { layoutSelect, layoutDispatch } from '/imports/ui/components/layout/context';
-import { useNumberOfPages } from '/imports/ui/components/video-provider/hooks';
+import { useNumberOfPages, useGridSize } from '/imports/ui/components/video-provider/hooks';
 import { VideoItem } from '/imports/ui/components/video-provider/types';
 import { Layout, Output } from '/imports/ui/components/layout/layoutTypes';
 import { PluginsContext } from '/imports/ui/components/components-data/plugin-context/context';
@@ -45,6 +45,7 @@ const VideoListContainer: React.FC<VideoListContainerProps> = (props) => {
     onVirtualBgDrop,
   } = props;
   const numberOfPages = useNumberOfPages();
+  const gridSize = useGridSize();
 
   const { pluginsExtensibleAreasAggregatedState } = useContext(PluginsContext);
 
@@ -118,6 +119,7 @@ const VideoListContainer: React.FC<VideoListContainerProps> = (props) => {
           onVideoItemMount={onVideoItemMount}
           onVideoItemUnmount={onVideoItemUnmount}
           onVirtualBgDrop={onVirtualBgDrop}
+          gridSize={gridSize}
         />
       )
   );

--- a/bigbluebutton-tests/playwright/core/elements.ts
+++ b/bigbluebutton-tests/playwright/core/elements.ts
@@ -507,6 +507,7 @@ export const elements = {
   webcamConnecting: 'div[data-test="webcamConnecting"]',
   webcamContainer: 'video[data-test="videoContainer"]',
   webcamVideoItem: 'div[data-test="webcamVideoItem"]',
+  overflowTile: 'div[data-test="overflowTile"]',
   videoDropdownMenu: 'button[data-test="videoDropdownMenu"]',
   advancedVideoSettingsBtn: 'li[data-test="advancedVideoSettingsButton"]',
   mirrorWebcamBtn: 'li[data-test="mirrorWebcamBtn"]',

--- a/bigbluebutton-tests/playwright/webcam/gridTileCount.spec.ts
+++ b/bigbluebutton-tests/playwright/webcam/gridTileCount.spec.ts
@@ -1,0 +1,30 @@
+import { test } from '../core/setup/fixtures';
+import { GridTileCount, MAX_GRID_SIZE } from './gridTileCount';
+
+// Regression test for issue 25073 (backport of PR 25103):
+// "Unified Layout: tile count plus aggregated users does not match total participant count".
+//
+// Precondition: the server under test must set a small grid size, e.g.
+//   public.kurento.pagination.desktopGridSizes: { moderator: 4, viewer: 4 }
+// so the overflow path can be exercised with a practical number of webcams.
+// (The issue's own reproduction likewise required a custom pagination config.)
+// When the configured grid size is larger than MAX_GRID_SIZE the test is skipped.
+test.describe('Grid layout participant tile count', () => {
+  test('tile count plus aggregated overflow equals total participants', async ({
+    browser,
+    context,
+    page,
+  }, testInfo) => {
+    const gridTileCount = new GridTileCount(browser, context);
+    await gridTileCount.initModPage(page, { testInfo });
+
+    const gridSize = await gridTileCount.getConfiguredGridSize();
+    test.skip(
+      !Number.isFinite(gridSize) || gridSize < 1 || gridSize > MAX_GRID_SIZE,
+      `requires public.kurento.pagination.desktopGridSizes <= ${MAX_GRID_SIZE} ` +
+        `to exercise the overflow path with a practical number of webcams (configured: ${gridSize})`,
+    );
+
+    await gridTileCount.checkTileCountMatchesParticipants(gridSize);
+  });
+});

--- a/bigbluebutton-tests/playwright/webcam/gridTileCount.spec.ts
+++ b/bigbluebutton-tests/playwright/webcam/gridTileCount.spec.ts
@@ -25,6 +25,10 @@ test.describe('Grid layout participant tile count', () => {
         `to exercise the overflow path with a practical number of webcams (configured: ${gridSize})`,
     );
 
+    // The test joins gridSize + 1 webcam users sequentially, so the timeout has to
+    // scale with the grid size (the default would be too short for large grids).
+    test.setTimeout((gridSize + 2) * 25_000 + 60_000);
+
     await gridTileCount.checkTileCountMatchesParticipants(gridSize);
   });
 });

--- a/bigbluebutton-tests/playwright/webcam/gridTileCount.ts
+++ b/bigbluebutton-tests/playwright/webcam/gridTileCount.ts
@@ -8,8 +8,10 @@ import { MultiUsers } from '../user/multiusers';
 // Above this grid size, exceeding the grid would require too many simultaneous
 // webcams to be practical in CI. The environment under test must therefore set
 // public.kurento.pagination.desktopGridSizes to a small value (the issue's own
-// reproduction also required a custom pagination config).
-export const MAX_GRID_SIZE = 8;
+// reproduction also required a custom pagination config). It can be raised via
+// GRID_TILE_COUNT_MAX_GRID_SIZE on a host with enough capacity to run the exact
+// pagination config from the issue (e.g. 24).
+export const MAX_GRID_SIZE = Number(process.env.GRID_TILE_COUNT_MAX_GRID_SIZE) || 8;
 
 export class GridTileCount extends MultiUsers {
   // Reads the effective grid size delivered to the client through meetingClientSettings.

--- a/bigbluebutton-tests/playwright/webcam/gridTileCount.ts
+++ b/bigbluebutton-tests/playwright/webcam/gridTileCount.ts
@@ -1,0 +1,82 @@
+import { expect } from '@playwright/test';
+
+import { ELEMENT_WAIT_LONGER_TIME } from '../core/constants';
+import { elements as e } from '../core/elements';
+import { Page } from '../core/page';
+import { MultiUsers } from '../user/multiusers';
+
+// Above this grid size, exceeding the grid would require too many simultaneous
+// webcams to be practical in CI. The environment under test must therefore set
+// public.kurento.pagination.desktopGridSizes to a small value (the issue's own
+// reproduction also required a custom pagination config).
+export const MAX_GRID_SIZE = 8;
+
+export class GridTileCount extends MultiUsers {
+  // Reads the effective grid size delivered to the client through meetingClientSettings.
+  async getConfiguredGridSize(): Promise<number> {
+    return this.modPage.page.evaluate(() => {
+      // @ts-ignore - injected on window by the client at runtime
+      const sizes = window.meetingClientSettings?.public?.kurento?.pagination?.desktopGridSizes;
+      return Number(sizes?.viewer ?? sizes?.moderator);
+    });
+  }
+
+  // Reproduces issue 25073: in the grid (video focus) layout, when the number of
+  // webcams exceeds the grid size, the sum of the visible tiles and the aggregated
+  // "+N" overflow tile must equal the total number of participants, and the number
+  // of visible tiles must never exceed the configured grid size.
+  async checkTileCountMatchesParticipants(gridSize: number): Promise<void> {
+    // One webcam more than the grid size guarantees the overflow tile appears.
+    const webcamUsers = gridSize + 1;
+    const totalParticipants = webcamUsers + 1; // + the moderator (observer, no webcam)
+
+    const viewers: Page[] = [];
+    for (let i = 0; i < webcamUsers; i += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      const viewerPage = await this.context.newPage();
+      const viewer = new Page(this.browser, viewerPage, this.modPage.testInfo);
+      // eslint-disable-next-line no-await-in-loop
+      await viewer.init(false, {
+        fullName: `Attendee${i + 1}`,
+        meetingId: this.modPage.meetingId,
+      });
+      // eslint-disable-next-line no-await-in-loop
+      await viewer.shareWebcam({ shouldConfirmSharing: true });
+      viewers.push(viewer);
+    }
+
+    // Switch the moderator to the grid (video focus) layout, which renders every
+    // participant as a tile.
+    await this.modPage.waitAndClick(e.optionsButton);
+    await this.modPage.waitAndClick(e.manageLayoutBtn);
+    await this.modPage.waitAndClick(e.focusOnVideo);
+    await this.modPage.waitAndClick(e.updateLayoutBtn);
+
+    // The layout may keep a second, off-screen video list for measurement. Both are
+    // the same component rendering the same data, so scope the counts to the single
+    // list that owns an overflow tile (its tiles are siblings of the overflow tile).
+    const overflowTile = this.modPage.page.locator(e.overflowTile).first();
+    await expect(
+      overflowTile,
+      'the aggregated overflow tile should appear when webcams exceed the grid size',
+    ).toBeVisible({ timeout: ELEMENT_WAIT_LONGER_TIME });
+
+    const videoList = overflowTile.locator('xpath=..');
+    const visibleTiles = await videoList.locator(e.webcamVideoItem).count();
+    const overflowText = await overflowTile.innerText();
+    const overflowCount = Number(overflowText.match(/\+\s*(\d+)/)?.[1] ?? '0');
+
+    // Core invariant from the bug report: visible tiles + aggregated users === total participants.
+    expect(
+      visibleTiles + overflowCount,
+      `visible tiles (${visibleTiles}) plus aggregated overflow (${overflowCount}) ` +
+        `should equal the ${totalParticipants} participants`,
+    ).toBe(totalParticipants);
+
+    // The grid must never render more tiles than its configured size.
+    expect(
+      visibleTiles,
+      `visible tiles (${visibleTiles}) should not exceed the grid size (${gridSize})`,
+    ).toBeLessThanOrEqual(gridSize);
+  }
+}


### PR DESCRIPTION
## What this fixes

In the grid (video focus) layout, when participant webcams exceed the configured grid size (`public.kurento.pagination.desktopGridSizes`), the surplus participants are collapsed into a single "+N users" tile. The number of visible tiles plus that aggregated count did not match the total number of participants, and the grid rendered more tiles than its configured size. Toggling a webcam on or off added or removed a tile instead of transitioning it, changing the visible count.

This is a backport to `v3.0.x-develop` of bigbluebutton/bigbluebutton#25103 (which fixed bigbluebutton/bigbluebutton#25073 on `v4.0.x-develop`). The same code path exists unchanged on 3.0, so the bug reproduces there as well.

## Root cause

In `video-list/component.tsx`:
1. `numItems` (used to size the grid) was `visibleStreams.length`, ignoring the grid size, so the grid was dimensioned for every visible stream instead of the page cap.
2. The overflow logic removed only "the last grid user" (`lastGridUserIndex`) instead of trimming every stream beyond the grid size. Webcam streams are not capped the way avatar grid users are, so this left too many tiles visible alongside the aggregated "+N" count.

## The fix

Identical to bigbluebutton/bigbluebutton#25103 (the `useGridSize` hook already exists on 3.0):
- clamp `numItems` to `gridSize` when the grid is enabled;
- compute `streamsToRender` by trimming exactly the streams beyond the grid size;
- thread `gridSize` from the `useGridSize` hook through the container.

## Files changed

- `bigbluebutton-html5/imports/ui/components/video-provider/video-list/component.tsx`
- `bigbluebutton-html5/imports/ui/components/video-provider/video-list/container.tsx`
- `bigbluebutton-tests/playwright/webcam/gridTileCount.spec.ts` (new regression test)
- `bigbluebutton-tests/playwright/webcam/gridTileCount.ts` (new test helper)
- `bigbluebutton-tests/playwright/core/elements.ts` (adds the `overflowTile` selector)

## Tests

Added a Playwright regression test (`webcam/gridTileCount.spec.ts`). It joins the moderator plus `gridSize + 1` webcam users, switches to the grid layout, and asserts that:
- visible tiles + aggregated overflow equals the total participant count;
- visible tiles never exceed the configured grid size.

The test requires a small `desktopGridSizes` to exercise the overflow path with a practical number of webcams (otherwise it skips), mirroring the issue's own reproduction precondition.

Verified on a BBB 3.0 environment built from `v3.0.x-develop` with `desktopGridSizes: 4` and 6 participants (5 webcams):

| state | visible tiles | overflow | sum | participants |
|-------|---------------|----------|-----|--------------|
| Before fix | 5 | +3 | 8 | 6 (mismatch) |
| After fix | 3 | +3 | 6 | 6 (match) |

The test fails on the unfixed client and passes on the fixed one.

## Evidence

Animated preview below - click the GIF to open the higher quality MP4.

Before (bug - 5 tiles plus "+3 users" claims 8, but only 6 participants):

[![Before fix](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-06-08/72d66cb9-45d4-4491-9696-e921de10051d/before.gif)](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-06-08/74918cf7-90a9-46b9-83a6-45b933f3f453/before-grid.mp4)

After (fixed - 3 tiles plus "+3 users" equals the 6 participants):

[![After fix](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-06-08/25edf22e-c12e-4523-ba80-2146a8537615/after.gif)](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-06-08/b05dba02-fe46-4db7-a88f-4bbd6c72b638/after-grid.mp4)

## Risk and notes

- Client only change, localized to the video grid rendering. No server or schema changes.
- Behaviour matches the upstream 4.0 fix already in production.
