### PR TITLE
fix: Unified Layout: tile count plus aggregated users does not match total participant count [3.0 backport]

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/component.tsx
@@ -85,6 +85,7 @@ interface VideoListProps {
   onVideoItemMount: (stream: string, video: HTMLVideoElement) => void;
   onVideoItemUnmount: (stream: string) => void;
   onVirtualBgDrop: (stream: string, type: string, name: string, data: string) => Promise<unknown>;
+  gridSize: number;
 }
 
 interface VideoListState {
@@ -227,11 +228,15 @@ class VideoList extends Component<VideoListProps, VideoListState> {
       streams,
       cameraDock,
       layoutContextDispatch,
+      isGridEnabled,
+      gridSize,
     } = this.props;
     const visibleStreams = streams.filter(
       (item) => item.type === VIDEO_TYPES.GRID || !('render' in item) || item.render !== false,
     );
-    let numItems = visibleStreams.length;
+    let numItems = isGridEnabled
+      ? Math.min(gridSize, visibleStreams.length)
+      : visibleStreams.length;
 
     if (numItems < 1 || !this.canvas || !this.grid) {
       return;
@@ -365,6 +370,7 @@ class VideoList extends Component<VideoListProps, VideoListState> {
       pluginUserCameraHelperPerPosition,
       isGridEnabled,
       overflowCount,
+      gridSize,
     } = this.props;
     const numOfStreams = streams.filter(
       (item) => item.type === VIDEO_TYPES.GRID || !('render' in item) || item.render !== false,
@@ -372,17 +378,10 @@ class VideoList extends Component<VideoListProps, VideoListState> {
 
     const shouldShowOverflowTile = isGridEnabled && overflowCount > 0;
 
-    let streamsToRender = streams;
-    if (shouldShowOverflowTile) {
-      const lastGridUserIndex = streams.map((s, idx) => ({ s, idx }))
-        .reverse()
-        .find(({ s }) => s.type === VIDEO_TYPES.GRID)?.idx;
-
-      if (lastGridUserIndex !== undefined) {
-        // remove the last grid user to replace it with the overflow tile
-        streamsToRender = streams.filter((_, idx) => idx !== lastGridUserIndex);
-      }
-    }
+    const streamsToHide = (numOfStreams - gridSize + 1) * -1;
+    const streamsToRender = shouldShowOverflowTile && streamsToHide < 0
+      ? streams.slice(0, streamsToHide)
+      : streams;
 
     const videoItems = streamsToRender.map((item) => {
       const { userId, name } = item;

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/container.tsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/container.tsx
@@ -6,7 +6,7 @@ import React, {
 import { UserCameraHelperButton, UserCameraHelperInterface, UserCameraHelperItemPosition } from 'bigbluebutton-html-plugin-sdk';
 import VideoList from '/imports/ui/components/video-provider/video-list/component';
 import { layoutSelect, layoutDispatch } from '/imports/ui/components/layout/context';
-import { useNumberOfPages } from '/imports/ui/components/video-provider/hooks';
+import { useNumberOfPages, useGridSize } from '/imports/ui/components/video-provider/hooks';
 import { VideoItem } from '/imports/ui/components/video-provider/types';
 import { Layout, Output } from '/imports/ui/components/layout/layoutTypes';
 import { PluginsContext } from '/imports/ui/components/components-data/plugin-context/context';
@@ -45,6 +45,7 @@ const VideoListContainer: React.FC<VideoListContainerProps> = (props) => {
     onVirtualBgDrop,
   } = props;
   const numberOfPages = useNumberOfPages();
+  const gridSize = useGridSize();
 
   const { pluginsExtensibleAreasAggregatedState } = useContext(PluginsContext);
 
@@ -118,6 +119,7 @@ const VideoListContainer: React.FC<VideoListContainerProps> = (props) => {
           onVideoItemMount={onVideoItemMount}
           onVideoItemUnmount={onVideoItemUnmount}
           onVirtualBgDrop={onVirtualBgDrop}
+          gridSize={gridSize}
         />
       )
   );

--- a/bigbluebutton-tests/playwright/core/elements.ts
+++ b/bigbluebutton-tests/playwright/core/elements.ts
@@ -507,6 +507,7 @@ export const elements = {
   webcamConnecting: 'div[data-test="webcamConnecting"]',
   webcamContainer: 'video[data-test="videoContainer"]',
   webcamVideoItem: 'div[data-test="webcamVideoItem"]',
+  overflowTile: 'div[data-test="overflowTile"]',
   videoDropdownMenu: 'button[data-test="videoDropdownMenu"]',
   advancedVideoSettingsBtn: 'li[data-test="advancedVideoSettingsButton"]',
   mirrorWebcamBtn: 'li[data-test="mirrorWebcamBtn"]',

--- a/bigbluebutton-tests/playwright/webcam/gridOverflow.spec.ts
+++ b/bigbluebutton-tests/playwright/webcam/gridOverflow.spec.ts
@@ -1,0 +1,87 @@
+import { expect } from '@playwright/test';
+import { test } from '../core/setup/fixtures';
+import { MultiUsers } from '../user/multiusers';
+import { Page } from '../core/page';
+import { elements as e } from '../core/elements';
+
+// Regression test for the Unified Layout webcam grid overflow bug
+// (backport of bigbluebutton/bigbluebutton#25103, issue #25073).
+//
+// When the presentation is minimized in the unified layout, participants are
+// shown as a tile grid. Above the grid limit (gridSize), the surplus is
+// aggregated into a single "+X" overflow tile. The invariant that must hold:
+//
+//     (visible tiles) + (aggregated overflow count) === (total grid participants)
+//
+// Before the fix the component dropped only the LAST grid user to make room for
+// the overflow tile, so the visible tile count and the aggregated count did not
+// add up to the participant total. The fix caps both the grid item count and the
+// overflow slicing by gridSize.
+//
+// REQUIRES a small webcam grid size on the server so the overflow tile appears
+// with only a handful of users. Set before running:
+//   yq -i '.public.kurento.pagination.desktopGridSizes.moderator = 4' /etc/bigbluebutton/bbb-html5.yml
+//   yq -i '.public.kurento.pagination.desktopGridSizes.viewer = 4'    /etc/bigbluebutton/bbb-html5.yml
+// (the test reads the real gridSize from the client, so any small value works as
+// long as TOTAL_USERS strictly exceeds it).
+const TOTAL_USERS = 6;
+
+test.describe('Webcam unified layout grid overflow', () => {
+  test('visible tiles plus aggregated overflow equals total participants', async ({
+    browser,
+    context,
+    page,
+  }, testInfo) => {
+    const m = new MultiUsers(browser, context);
+
+    // Moderator creates the meeting and shares a webcam.
+    await m.initModPage(page, { fullName: 'Mod', testInfo });
+    await m.modPage.shareWebcam();
+
+    // Remaining viewers join the same meeting and share a webcam each, so every
+    // participant is a tile in the grid.
+    const extraPages: Page[] = [];
+    for (let i = 1; i < TOTAL_USERS; i += 1) {
+      const userBrowserPage = await context.newPage();
+      const userPage = new Page(browser, userBrowserPage, m.modPage.testInfo);
+      await userPage.init(false, { fullName: `User${i}`, meetingId: m.modPage.meetingId });
+      await userPage.shareWebcam();
+      extraPages.push(userPage);
+    }
+
+    // Read the grid size actually applied by the client.
+    const gridSize: number = await m.modPage.page.evaluate(
+      () => window.meetingClientSettings.public.kurento.pagination.desktopGridSizes.moderator,
+    );
+    expect(
+      TOTAL_USERS,
+      `this test needs more participants than the configured gridSize (${gridSize}) to force an overflow tile`,
+    ).toBeGreaterThan(gridSize);
+
+    // Switch to the unified/video-focus layout and minimize the presentation so
+    // the participants fill the screen as a grid.
+    await m.modPage.waitAndClick(e.optionsButton);
+    await m.modPage.waitAndClick(e.manageLayoutBtn);
+    await m.modPage.waitAndClick(e.focusOnVideo);
+    await m.modPage.waitAndClick(e.updateLayoutBtn);
+    await m.modPage.closeAllToastNotifications();
+
+    // The overflow tile must be present (more participants than gridSize).
+    await m.modPage.page.locator(e.overflowTile).first().waitFor({ state: 'visible' });
+
+    const visibleTiles = await m.modPage.getSelectorCount(e.webcamVideoItem);
+    const overflowText = (await m.modPage.page.locator(e.overflowTile).first().textContent()) ?? '';
+    const overflowCount = parseInt((overflowText.match(/\+(\d+)/) ?? ['', '0'])[1], 10);
+
+    // eslint-disable-next-line no-console
+    console.log(
+      `[gridOverflow] gridSize=${gridSize} totalUsers=${TOTAL_USERS} ` +
+        `visibleTiles=${visibleTiles} overflowCount=${overflowCount} sum=${visibleTiles + overflowCount}`,
+    );
+
+    expect(
+      visibleTiles + overflowCount,
+      'visible tiles plus the aggregated overflow count should equal the total number of participants',
+    ).toBe(TOTAL_USERS);
+  });
+});


### PR DESCRIPTION
### What does this PR do?

Backport of bigbluebutton/bigbluebutton#25103 (originally for `v4.0.x-develop`, issue bigbluebutton/bigbluebutton#25073) to the 3.0 line (`v3.0.x-develop`).

In the unified layout, when the presentation is minimized, participants are shown as a tile grid. When the number of participants exceeds the grid limit (`gridSize`), the surplus is aggregated into a single "+X participants" tile. The 3.0 line has the same bug as 4.0: the sum of the visible tiles and the aggregated count does not always match the total number of participants, and toggling a camera adds or removes a tile instead of transitioning it between camera and avatar.

Root cause: the old code dropped only the **last grid-type user** to make room for the overflow tile. When participants share a camera there is no grid-type stream to drop, so every camera tile is rendered **plus** the overflow tile, inflating the apparent participant count. The fix caps both the grid item count and the overflow slicing by `gridSize` (using the existing `useGridSize` hook), so `visible tiles + aggregated overflow === total participants`.

The code change is identical to the upstream fix. `useGridSize` already exists on 3.0, so the cherry-pick applies cleanly with no conflicts.

### Reproduced and validated on a BBB 3.0 from-source environment

Built from `v3.0.x-develop`, `public.kurento.pagination.desktopGridSizes` set to 4, with 6 participants sharing a camera in the unified-layout grid:

| | Visible camera tiles | Aggregated tile | Sum | Actual participants |
|---|---|---|---|---|
| **Before** | 6 | "+3" | **9** :x: | 6 |
| **After** | 3 | "+3" | **6** :white_check_mark: | 6 |

**Before the fix** - 6 camera tiles **and** a "+3 users" tile, implying 9 participants when only 6 joined:

[![Before fix screenshot](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-06-09/6c8b1b31-87de-4dfd-b6bd-2466ab903697/before-mod-grid.png)](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-06-09/6c8b1b31-87de-4dfd-b6bd-2466ab903697/before-mod-grid.png)

Animated demo below - click the GIF to open the MP4 (higher quality, with controls):

[![Before fix demo](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-06-09/a8b426c8-04f1-4993-8ac5-7c3dae212aee/before-demo.gif)](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-06-09/cd4865c4-1153-4dfb-b0ba-e46ea51c38f2/before-demo.mp4)

**After the fix** - 3 camera tiles and a "+3 users" tile, correctly totaling 6:

[![After fix screenshot](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-06-09/1fedd308-edc3-44cd-8739-c776d06c1882/after-mod-grid.png)](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-06-09/1fedd308-edc3-44cd-8739-c776d06c1882/after-mod-grid.png)

Animated demo below - click the GIF to open the MP4 (higher quality, with controls):

[![After fix demo](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-06-09/3bf69bf5-de5a-415f-b207-eecf7de4a2cd/after-demo.gif)](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-06-09/0673b5fe-3c8f-4216-827a-460178cd0918/after-demo.mp4)

### Automated test

Adds `bigbluebutton-tests/playwright/webcam/gridOverflow.spec.ts`: it joins several webcam users in the unified-layout grid with a small `gridSize`, forcing the overflow tile, reads the real `gridSize` from the client, and asserts `visible tiles + aggregated overflow count === total participants`.

The test fails before the fix and passes after (same environment, same scenario):

```text
# before the fix
[gridOverflow] gridSize=4 totalUsers=6 visibleTiles=6 overflowCount=3 sum=9
  x  webcam/gridOverflow.spec.ts - visible tiles plus aggregated overflow equals total participants
     Error: visible tiles plus the aggregated overflow count should equal the total number of participants
     Expected: 6
     Received: 9
  1 failed

# after the fix
[gridOverflow] gridSize=4 totalUsers=6 visibleTiles=3 overflowCount=3 sum=6
  ok  webcam/gridOverflow.spec.ts - visible tiles plus aggregated overflow equals total participants
  2 passed
```

### How to test

1. Set `public.kurento.pagination.desktopGridSizes` to a small value (e.g. 4) in `bbb-html5.yml`.
2. Create a meeting and join more participants than the grid size (e.g. 6), each sharing a camera.
3. Use the unified-layout grid (minimize the presentation).
4. Count the visible camera tiles plus the "+X" aggregated tile: it should equal the total participant count.
