### PR TITLE
fix(shared-notes): show unread indicator for BlockNote notes

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/SharedNotesRevDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/SharedNotesRevDAO.scala
@@ -49,7 +49,7 @@ object SharedNotesRevDAO {
   def insertNextRev(meetingId: String, sharedNotesExtId: String, userId: String) = {
     DatabaseConnection.enqueue(
       sqlu"""
-          insert into "sharedNotes_rev"("meetingId", "sharedNotesExtId", "userId", "rev")
+          insert into "sharedNotes_rev"("meetingId", "sharedNotesExtId", "userId", "rev", "createdAt")
            select
              ${meetingId} as "meetingId",
              ${sharedNotesExtId} as "sharedNotesExtId",
@@ -58,7 +58,8 @@ object SharedNotesRevDAO {
                 from "sharedNotes_rev"
                 where "meetingId" = ${meetingId}
                 and "sharedNotesExtId" = ${sharedNotesExtId}
-             ),0) + 1 as "rev"
+             ),0) + 1 as "rev",
+             current_timestamp as "createdAt"
           """
     )
   }

--- a/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
@@ -28,6 +28,7 @@ import { colorWhite } from '/imports/ui/stylesheets/styled-components/palette';
 import { useBlockNoteLocaleLanguage, useHocuspocusProvider } from './hooks';
 import useMeeting from '/imports/ui/core/hooks/useMeeting';
 import useCurrentUser from '../../core/hooks/useCurrentUser';
+import useNotesLastRead from '/imports/ui/components/notes/hooks/useNotesLastRead';
 import logger from '/imports/startup/client/logger';
 import { notify } from '../../services/notification';
 import TextAlignSelect from './text-align-select/component';
@@ -378,10 +379,15 @@ function BlockNoteApp(props: BlockNoteAppProps): React.ReactElement {
   );
 }
 
-function BlockNoteContainer(): React.ReactElement {
+interface BlockNoteContainerProps {
+  isVisible: boolean;
+}
+
+function BlockNoteContainer({ isVisible }: BlockNoteContainerProps): React.ReactElement {
   const {
     error, isAuthenticating, hocuspocusProvider, connectionClosed, handleRetry, isSynced,
   } = useHocuspocusProvider();
+  const { markNotesAsRead } = useNotesLastRead();
 
   const { data: currentUser } = useCurrentUser((user) => ({
     color: user.color,
@@ -402,6 +408,19 @@ function BlockNoteContainer(): React.ReactElement {
 
   const renderBlockNote = !error && !isAuthenticating
     && hocuspocusProvider && !connectionClosed && isSynced;
+
+  // The notes are read when the synced editor is on screen. Mirror the
+  // etherpad pad (pads-graphql/component.tsx): mark as read on show and on
+  // hide - the panel stays mounted for NOTES_UNMOUNT_DELAY after closing,
+  // and edits arriving in that window must stay unread.
+  React.useEffect(() => {
+    if (!renderBlockNote) return () => {};
+    if (isVisible) markNotesAsRead();
+    return () => {
+      if (isVisible) markNotesAsRead();
+    };
+  }, [renderBlockNote, isVisible, markNotesAsRead]);
+
   return (
     <Styled.Notes id="bn-notes-scroll-container">
       {(hasError) && (

--- a/bigbluebutton-html5/imports/ui/components/notes/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/notes/component.tsx
@@ -182,7 +182,7 @@ const NotesGraphql: React.FC<NotesGraphqlProps> = (props) => {
             amIPresenter={amIPresenter}
             isVisible={isVisible}
           />
-        ) : <BlockNoteContainer />}
+        ) : <BlockNoteContainer isVisible={isVisible} />}
     </Styled.PanelContent>
   );
 };

--- a/bigbluebutton-tests/playwright/core/elements.ts
+++ b/bigbluebutton-tests/playwright/core/elements.ts
@@ -267,6 +267,7 @@ export const elements = {
   etherpadOuter: 'iframe[title="Ether"]',
   etherpadInner: 'iframe[title="pad"]',
   etherpadEditable: 'body[id="innerdocbody"]',
+  blockNoteEditor: 'div#bn-notes-scroll-container div.bn-editor',
   sendNotesToWhiteboard: 'li[data-test="moveNotesToWhiteboard"]',
   presentationUploadProgressToast: 'div[data-test="presentationUploadProgressToast"]',
   sharedNotesViewingMode: 'iframe[title="shared notes viewing mode"]',

--- a/bigbluebutton-tests/playwright/sharednotes/blocknote/sharednotes.spec.ts
+++ b/bigbluebutton-tests/playwright/sharednotes/blocknote/sharednotes.spec.ts
@@ -1,0 +1,20 @@
+import { initializePages } from '../../core/helpers';
+import { test } from '../../core/setup/fixtures';
+import { SharedNotes } from './sharednotes';
+
+test.describe.parallel('Shared Notes - BlockNote', { tag: '@ci' }, () => {
+  let sharedNotes: SharedNotes;
+
+  test.beforeEach(async ({ browser, context }, testInfo) => {
+    sharedNotes = new SharedNotes(browser, context);
+    await initializePages(sharedNotes, browser, {
+      isMultiUser: true,
+      createParameter: 'sharedNotesEditor=blockNote',
+      testInfo,
+    });
+  });
+
+  test('Unread indicator notifies users of new notes content', async () => {
+    await sharedNotes.unreadNotesIndicator();
+  });
+});

--- a/bigbluebutton-tests/playwright/sharednotes/blocknote/sharednotes.ts
+++ b/bigbluebutton-tests/playwright/sharednotes/blocknote/sharednotes.ts
@@ -1,0 +1,48 @@
+import { elements as e } from '../../core/elements';
+import { MultiUsers } from '../../user/multiusers';
+import {
+  getNotesLocator,
+  hasNoUnreadNotesIndicator,
+  startSharedNotes,
+  unreadNotesIndicatorStaysHidden,
+} from './util';
+
+export class SharedNotes extends MultiUsers {
+  async unreadNotesIndicator() {
+    const { sharedNotesEnabled } = this.modPage.settings || {};
+
+    if (!sharedNotesEnabled) {
+      await this.modPage.hasElement(e.messagesSidebarButton, 'should display the public chat button');
+      await this.modPage.wasRemoved(e.sharedNotesSidebarButton, 'should not display the shared notes button');
+      return;
+    }
+
+    // viewer starts without the unread indicator
+    await this.userPage.hasElement(e.sharedNotesSidebarButton, 'should display the shared notes button');
+    await hasNoUnreadNotesIndicator(this.userPage, 'should not display the unread indicator before any edit');
+
+    // moderator opens the notes and types
+    await startSharedNotes(this.modPage);
+    const notesEditor = getNotesLocator(this.modPage);
+    await notesEditor.click();
+    await this.modPage.page.keyboard.type('Hello attendees');
+
+    // viewer (notes panel closed) must see the unread indicator
+    await this.userPage.hasNotificationIcon(e.sharedNotesSidebarButton, 'should display the unread indicator for the viewer');
+
+    // opening the notes clears the indicator
+    await startSharedNotes(this.userPage);
+    await hasNoUnreadNotesIndicator(this.userPage, 'should clear the unread indicator when the notes panel is open');
+
+    // closing the panel must not bring the indicator back (notes were read)
+    await this.userPage.waitAndClick(e.hideNotesLabel);
+    await this.userPage.wasRemoved(e.hideNotesLabel, 'should not display the hide notes label');
+    await unreadNotesIndicatorStaysHidden(this.userPage, 'should keep the indicator hidden after reading the notes');
+
+    // new edits after the viewer read the notes must light the indicator again
+    const modNotesEditor = getNotesLocator(this.modPage);
+    await modNotesEditor.click();
+    await this.modPage.page.keyboard.type('New content');
+    await this.userPage.hasNotificationIcon(e.sharedNotesSidebarButton, 'should display the unread indicator again after new edits');
+  }
+}

--- a/bigbluebutton-tests/playwright/sharednotes/blocknote/util.ts
+++ b/bigbluebutton-tests/playwright/sharednotes/blocknote/util.ts
@@ -1,0 +1,40 @@
+import { expect } from '@playwright/test';
+
+import { ELEMENT_WAIT_LONGER_TIME, ELEMENT_WAIT_TIME } from '../../core/constants';
+import { elements as e } from '../../core/elements';
+import { Page } from '../../core/page';
+
+export async function startSharedNotes(testPage: Page) {
+  await testPage.waitAndClick(e.sharedNotesSidebarButton);
+  await testPage.waitForSelector(e.hideNotesLabel, ELEMENT_WAIT_LONGER_TIME);
+  await testPage.hasElement(e.blockNoteEditor, 'should display the BlockNote editor', ELEMENT_WAIT_LONGER_TIME);
+}
+
+export function getNotesLocator(testPage: Page) {
+  return testPage.page.locator(e.blockNoteEditor);
+}
+
+function checkUnreadNotesIndicator(testPage: Page) {
+  return testPage.page.evaluate((selector) => {
+    const element = document.querySelector(selector);
+    if (!element) return false;
+    const afterElement = getComputedStyle(element, 'after');
+    return !!afterElement && afterElement.content !== 'none';
+  }, e.sharedNotesSidebarButton);
+}
+
+export async function hasNoUnreadNotesIndicator(testPage: Page, description: string, timeout = ELEMENT_WAIT_TIME) {
+  await expect(async () => {
+    expect(await checkUnreadNotesIndicator(testPage)).toBeFalsy();
+  }, description).toPass({ timeout });
+}
+
+// The indicator must not (re)appear: poll for the whole duration instead of
+// passing on the first falsy check.
+export async function unreadNotesIndicatorStaysHidden(testPage: Page, description: string, durationMs = 3000) {
+  const deadline = Date.now() + durationMs;
+  while (Date.now() < deadline) {
+    expect(await checkUnreadNotesIndicator(testPage), description).toBeFalsy();
+    await testPage.page.waitForTimeout(250);
+  }
+}


### PR DESCRIPTION
## Summary

On 4.0, when the shared notes use the BlockNote editor (`sharedNotesEditor=blockNote`), the red unread dot on the sidebar notes button never appears - users with the panel closed get no hint that someone is writing. With the etherpad editor the indicator works as expected.

Expected behavior: editing the notes lights the red dot for every user whose notes panel is closed; opening the panel clears it; new edits after that light it again.

Impact: in BlockNote meetings, new shared notes content goes completely unnoticed by anyone with the panel closed.

This PR makes the BlockNote path feed the same unread mechanism the etherpad path already uses (the `lastUpdatedAt` timestamp streamed to the client) and makes the BlockNote panel mark the notes as read at the same moments the etherpad pad does.

Fixes the regression reported in https://github.com/bigbluebutton/bigbluebutton/issues/25250.

## Root Cause

The sidebar indicator is computed client-side as `lastUpdatedAt > lastReadTimestamp` (`useHasUnreadNotes`):

- `lastUpdatedAt` comes from a GraphQL subscription on `v_sharedNotes`, defined as `max("createdAt")` over the `sharedNotes_rev` table (`bbb-graphql-server/bbb_schema.sql`).
- `lastReadTimestamp` is a client-side reactive var set by `markNotesAsRead()` (`useNotesLastRead`).

Two gaps, both specific to the BlockNote path:

1. When a BlockNote document changes, `bbb-shared-notes-server` emits `BNSharedNotesUpdatedEvtMsg` and akka-apps records the revision via `SharedNotesRevDAO.insertNextRev` - a raw SQL insert that does not fill `createdAt`. Every revision lands with `createdAt = NULL`, so `max("createdAt")` is NULL, `lastUpdatedAt` never materializes and the client keeps `0` forever (`useNotesLastUpdatedAt` ignores null values). The etherpad path goes through `PadUpdatedSysMsgHdlr` -> `SharedNotesRevDAO.insert`, which does fill `createdAt` - that is why etherpad meetings show the dot and BlockNote meetings do not.
2. The BlockNote panel (`bn-shared-notes/component.tsx`) never calls `markNotesAsRead()`. The etherpad pad marks the notes as read when the iframe loads and when the pad leaves the screen (`pads/pads-graphql/component.tsx`). Without the equivalent, even with gap 1 fixed, the dot would relight for content the user had already seen - and edits arriving while the closed panel is still mounted (the panel stays mounted for `delayForUnmountOfSharedNote` = 2 minutes after closing) would be silently marked as read.

Introduced by the BlockNote integration in https://github.com/bigbluebutton/bigbluebutton/pull/24519 (commit 250ab445ab) - `insertNextRev` was added there without `createdAt`, and the new editor component shipped without the read-marking the pad component has. The indicator has therefore never worked for BlockNote meetings (4.0.0-beta.x).

Database evidence from a live 4.0 meeting (v4.0.x-develop from source), before the fix - 148 revisions recorded while typing, all with `createdAt` NULL, view aggregate NULL:

- [SQL before the fix](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-06-11/7fbb40e4-74fd-4a72-a1fd-4bec30cd1b8b/25250-sql-before.txt)
- [SQL after the fix](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-06-11/78175707-25d0-46a2-bdca-c31717577ad0/25250-sql-after.txt) (every revision timestamped, `lastUpdatedAt` live)

## Implementation

Two localized changes, mirroring what the etherpad path already does:

- **`akka-bbb-apps/.../core/db/SharedNotesRevDAO.scala`** - `insertNextRev` now fills `"createdAt"` with `current_timestamp`. This is the column the `v_sharedNotes.lastUpdatedAt` aggregation reads; with it, every BlockNote edit bumps `lastUpdatedAt` and Hasura streams the new value to subscribed clients. No schema or metadata change needed - the column and the view already exist.
- **`bigbluebutton-html5/.../components/bn-shared-notes/component.tsx`** (+ one prop in `components/notes/component.tsx`) - `BlockNoteContainer` now marks the notes as read at the same observable moments the etherpad pad does: when the synced editor is shown and when it is hidden. The hide-time marking matters because the panel stays mounted for `delayForUnmountOfSharedNote` (2 min) after closing: marking on unmount instead would swallow edits arriving in that window. Implemented with the existing `useNotesLastRead()` hook + one `useEffect` keyed on the existing `renderBlockNote` condition and the panel visibility (`isVisible`, threaded from the notes container exactly like the etherpad branch already receives it).

Alternatives considered:

- Client-only workaround (deriving "unread" from Yjs document events): rejected - the timestamp source of truth already exists and works for etherpad; BlockNote should feed the same pipeline, not grow a parallel one.
- Filling `createdAt` from the JVM clock (as the etherpad-path `insert` does): equivalent in practice; `current_timestamp` keeps the whole statement in SQL and uses the same clock Postgres uses to serve the view.

Files changed:

| File | Why |
|---|---|
| `akka-bbb-apps/.../core/db/SharedNotesRevDAO.scala` | Root cause 1: BlockNote revision rows missing `createdAt`, starving `v_sharedNotes.lastUpdatedAt` |
| `bigbluebutton-html5/.../components/bn-shared-notes/component.tsx` | Root cause 2: BlockNote panel never marked the notes as read (on show / on hide) |
| `bigbluebutton-html5/.../components/notes/component.tsx` | Threads the existing `isVisible` to the BlockNote container (1 line), enabling the hide-time marking |
| `bigbluebutton-tests/playwright/core/elements.ts` | New `blockNoteEditor` selector used by the new spec |
| `bigbluebutton-tests/playwright/sharednotes/blocknote/*` | New e2e spec covering the unread indicator end to end |

## Test Coverage

**`Shared Notes - BlockNote > Unread indicator notifies users of new notes content`** (new)

- Objective: validate the full unread indicator lifecycle in a meeting created with `sharedNotesEditor=blockNote`.
- Setup: 1 moderator + 1 attendee (suite `initializePages` with `isMultiUser: true`).
- Assertions:
  1. attendee starts with no indicator;
  2. after the moderator types with the attendee's panel closed, the dot appears for the attendee;
  3. opening the notes clears the dot;
  4. the dot stays hidden after closing the panel (content was read) - polled for 3s;
  5. new edits after that make the dot reappear.
- Pre-fix run: failed at assertion 2, the dot never appears ([log](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-06-11/74154825-aabf-43fa-b214-2594b3bbbba4/25250-e2e-before-fail.txt)).
- Post-fix run: passed, 21.3s ([log](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-06-11/1f0b367a-f387-4e4b-a4d4-bed412ce6058/25250-e2e-after-pass.txt)).

Regression - existing `Shared Notes - Etherpad` spec re-run post-fix ([log](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-06-11/7b7e9ba2-45e5-4149-a8c6-351e5c33800d/25250-e2e-etherpad-regression.txt)): 7 of 8 tests passed. The single failure is `Type in shared notes`, on its `toHaveScreenshot` comparison (224 pixels / 1% diff vs the committed baseline, `maxDiffPixels: 150`) - font antialiasing variance of the test environment against a baseline generated elsewhere, the same rendering-sensitivity the spec itself acknowledges (it skips on firefox for "different fonts"). The functional assertion of that very test (typed/edited text present in the pad) passed, and the etherpad code path is untouched by this PR (the DAO change only runs for `BNSharedNotesUpdatedEvtMsg`; the client change only mounts in the BlockNote branch).

## Manual Test Cases

| Scenario | Expected | Result |
|---|---|---|
| BlockNote: moderator types, viewer panel closed | dot appears for the viewer | OK (video, e2e) |
| BlockNote: viewer opens the notes | dot clears | OK (video, e2e) |
| BlockNote: viewer closes the panel after reading | dot stays hidden | OK (video, e2e) |
| BlockNote: moderator types again after viewer read | dot reappears | OK (video, e2e) |
| BlockNote: edits while panel open | no dot while reading | OK (video) |
| Etherpad meeting (regression) | indicator machinery and pad behavior unchanged | OK (7/8 spec, see note above) |

## Evidence

All runs on a from-source 4.0 environment (`v4.0.x-develop` @ 8768637f78), meetings created with `sharedNotesEditor=blockNote`, 1 moderator (typist) + 1 viewer.

**Before the fix** - viewer perspective ([MP4](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-06-11/cbef5a77-2c5e-4fb5-a297-71e7486f3784/25250-before-viewer.mp4), 1:01): demonstrates the bug.

- ~0:07-0:14 - moderator opens the notes and types two sentences; viewer's panel is closed
- ~0:14-0:30 - no dot ever appears on the viewer's notes button ([frame](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-06-11/d1125d4b-8d49-4fb7-a975-c70c533c266c/25250-before-no-dot.png))
- ~0:30-0:36 - viewer opens the notes (content did sync - the data path works, only the indicator is dead) and closes them
- ~0:40-1:01 - moderator types again; still no dot through the end of the video

**After the fix** - viewer perspective ([MP4](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-06-11/49d97603-83e6-4a8f-8c3b-7dba057d118e/25250-after-viewer.mp4), 0:38; [editor perspective](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-06-11/862994a9-9952-4794-bb75-e127fc1b9611/25250-after-editor.mp4)):

- ~0:18-0:25 - moderator types; **the dot lights on the viewer's notes button in real time** ([frame](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-06-11/cc94a424-5b8e-4fd9-8dc8-8b258e75ceb9/25250-after-dot.png))
- ~0:26-0:30 - viewer opens the notes: content is there, dot clears
- ~0:31-0:33 - viewer closes the panel: dot stays off (content was read)
- ~0:34-0:38 - moderator types one more line: dot reappears

Preview animado abaixo - clique no GIF pra abrir o MP4 (qualidade maior, com controls):

[![Unread dot appearing for the viewer after the fix](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-06-11/94433d24-ab58-4c1b-86c5-0864c6610fce/25250-after-dot.gif)](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-06-11/49d97603-83e6-4a8f-8c3b-7dba057d118e/25250-after-viewer.mp4)

Database evidence (same meetings): [before](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-06-11/7fbb40e4-74fd-4a72-a1fd-4bec30cd1b8b/25250-sql-before.txt) - 148 revisions, all `createdAt` NULL, `v_sharedNotes.lastUpdatedAt` NULL; [after](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-06-11/78175707-25d0-46a2-bdca-c31717577ad0/25250-sql-after.txt) - every revision timestamped and `lastUpdatedAt` following the latest edit.

## Risks / Notes

- `markNotesAsRead` timing mirrors the etherpad pad. Edits arriving during the 2-minute mounted-but-hidden window after closing the panel correctly stay unread (hide-time marking, not unmount-time).
- The redesigned sidebar buttons (chat and notes) expose the unread state visually only (CSS `::after` dot) with no aria attribute - the intl strings for it exist but are unused since the redesign, for both chat and notes. Pre-existing and out of scope here; worth a follow-up issue.
- `insertNextRev` computes `max(rev)+1` non-atomically (pre-existing); not aggravated by this change.
