### PR TITLE
fix(chat): preserve text before links in reply message preview

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/service.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/service.ts
@@ -1,3 +1,42 @@
+const lineBreakingTags = new Set(['P', 'DIV', 'PRE', 'H1', 'H2', 'H3', 'H4', 'H5', 'H6', 'UL', 'OL', 'LI', 'BLOCKQUOTE', 'TABLE', 'TR', 'TD']);
+
+// Truncates the subtree at the first visual line break: a newline inside a
+// text node (rendered as a break by `white-space: pre-wrap`), a <br>, or the
+// end of the first nested line-breaking element. Returns true when the line
+// ended inside the given node, so callers must drop the siblings that follow.
+const truncateAtFirstLineBreak = (node: Node): boolean => {
+  if (node.nodeType === Node.TEXT_NODE) {
+    const text = node.textContent || '';
+    // whitespace-only nodes are markup formatting between elements, not a visual break
+    if (!text.trim()) return false;
+    const newlineIndex = text.indexOf('\n');
+    if (newlineIndex === -1) return false;
+    // eslint-disable-next-line no-param-reassign
+    node.textContent = text.slice(0, newlineIndex);
+    return true;
+  }
+
+  if (node.nodeType !== Node.ELEMENT_NODE) return false;
+
+  const element = node as Element;
+  if (element.tagName === 'BR') {
+    element.remove();
+    return true;
+  }
+
+  let lineEnded = false;
+  Array.from(element.childNodes).forEach((child) => {
+    if (lineEnded) {
+      child.remove();
+      return;
+    }
+    lineEnded = truncateAtFirstLineBreak(child)
+      || (child.nodeType === Node.ELEMENT_NODE && lineBreakingTags.has((child as Element).tagName));
+  });
+
+  return lineEnded;
+};
+
 export const getFirstVisibleLineHtml = (htmlContent: string): string => {
   if (!htmlContent.trim()) return '';
 
@@ -6,35 +45,7 @@ export const getFirstVisibleLineHtml = (htmlContent: string): string => {
   const root = doc.body.firstElementChild;
   if (!root) return '';
 
-  const displayBlockTags = new Set(['P', 'A', 'DIV', 'PRE', 'H1', 'H2', 'H3', 'H4', 'H5', 'H6', 'UL', 'OL', 'LI', 'BLOCKQUOTE', 'TABLE', 'TR', 'TD', 'CODE']);
-
-  const children = Array.from(root.childNodes);
-  let keptBlocks = 0;
-
-  for (let i = children.length - 1; i >= 0; i -= 1) {
-    const node = children[i];
-
-    if (node.nodeType === Node.ELEMENT_NODE) {
-      const tagName = (node as Element).tagName.toUpperCase();
-      if (displayBlockTags.has(tagName)) {
-        if (keptBlocks === 0) {
-          keptBlocks = 1;
-        } else {
-          node.remove();
-        }
-      } else if (keptBlocks > 0) {
-        node.remove();
-      }
-    } else if (node.nodeType === Node.TEXT_NODE) {
-      if (keptBlocks > 0) {
-        node.remove();
-      } else {
-        const text = node.textContent || '';
-        const firstLine = text.split(/\n/)[0];
-        node.textContent = firstLine;
-      }
-    }
-  }
+  truncateAtFirstLineBreak(root);
 
   return root.outerHTML;
 };

--- a/bigbluebutton-tests/playwright/chat/chat.spec.ts
+++ b/bigbluebutton-tests/playwright/chat/chat.spec.ts
@@ -203,6 +203,12 @@ test.describe.parallel('Chat', { tag: '@ci' }, () => {
         await message.replyMessage();
       });
 
+      test('Reply to a message with text followed by a link', async ({ browser, context, page }, testInfo) => {
+        const message = new MessageActions(browser, context);
+        await message.initModPage(page, { testInfo });
+        await message.replyMessageWithTextBeforeLink();
+      });
+
       test('Cancel a reply to a message', async ({ browser, context, page }, testInfo) => {
         const message = new MessageActions(browser, context);
         await message.initModPage(page, { testInfo });

--- a/bigbluebutton-tests/playwright/chat/messageActions.ts
+++ b/bigbluebutton-tests/playwright/chat/messageActions.ts
@@ -415,6 +415,51 @@ export class MessageActions extends Chat {
     await expect(messageReplied, 'should display the replied message content in the message sent').toBeVisible();
   }
 
+  async replyMessageWithTextBeforeLink() {
+    await openPublicChat(this.modPage);
+    // send a message containing text followed by a link
+    await this.modPage.fill(e.chatBox, e.messageWithTextBeforeLink);
+    await this.modPage.waitAndClick(e.sendButton);
+    await this.modPage.hasElement(
+      e.chatUserMessageText,
+      'should display the message sent by the moderator on the public chat',
+    );
+    await checkLastMessageSent(this.modPage, e.messageWithTextBeforeLink);
+    const initialMessagesCount = await this.modPage.getSelectorCount(e.chatUserMessageText);
+    // hover message and click to reply
+    const lastMessageItem = this.modPage.page.locator(e.chatMessageItem).last();
+    await lastMessageItem.hover();
+    await expect(
+      lastMessageItem.locator(e.messageToolbar),
+      'should display the message toolbar when hovering a message',
+    ).toBeVisible();
+    await this.modPage.waitAndClick(e.replyMessageButton);
+    // the reply intention preview must keep the whole first line: the text and the link
+    await this.modPage.hasElement(
+      e.chatReplyIntentionContainerContent,
+      'should display the chat reply intention container content',
+    );
+    await this.modPage.hasText(
+      e.chatReplyIntentionContainerContent,
+      e.messageWithTextBeforeLink,
+      'should display the full first line (text and link) in the reply intention preview',
+    );
+    // reply the message
+    await this.modPage.fill(e.chatBox, e.message2);
+    await this.modPage.waitAndClick(e.sendButton);
+    await this.modPage.hasElementCount(
+      e.chatUserMessageText,
+      initialMessagesCount + 1,
+      'should display the reply as a new message',
+    );
+    // the quote inside the sent reply must keep the whole first line as well
+    const messageReplied = this.modPage.page.locator(e.chatMessageItem).last().locator(e.chatMessageReplied);
+    await expect(
+      messageReplied,
+      'should display the full first line (text and link) in the replied message quote',
+    ).toContainText(e.messageWithTextBeforeLink);
+  }
+
   async cancelReplyMessage() {
     await openPublicChat(this.modPage);
     // send a message

--- a/bigbluebutton-tests/playwright/core/elements.ts
+++ b/bigbluebutton-tests/playwright/core/elements.ts
@@ -224,6 +224,7 @@ export const elements = {
   testMessage: 'Just a test',
   message1: 'Hello User2',
   message2: 'Hello User1',
+  messageWithTextBeforeLink: 'Hello https://example.com',
   publicMessage1: 'This is a Public Message from User1',
   publicMessage2: 'This is a Public Message from User2',
   uniqueCharacterMessage: 'A',


### PR DESCRIPTION
Closes bigbluebutton/bigbluebutton#25251

## Summary

When replying to a chat message that contains text followed by a link (e.g. `Hello https://example.com`), both reply previews - the "replying to" banner above the message input and the quote rendered inside the sent reply - display only the link. Any text that precedes the link on the same line is silently dropped.

Expected: the preview shows the full first line of the original message, exactly as it was rendered in the chat.

Impact: users replying to messages that start with text and end with a URL (a very common shape: "check this out https://...") produce replies whose quote misrepresents the original message, losing the context the reply refers to.

This PR fixes the first-line extraction so the whole first visible line - text, links, inline code, emphasis - is preserved in both previews.

## Root Cause

The reply previews render `getFirstVisibleLineHtml(messageAsHtml)` (`bigbluebutton-html5/imports/ui/components/chat/chat-graphql/service.ts`), where `messageAsHtml` is the server-rendered HTML produced by akka-apps (`MarkdownUtil.markdownToSafeHtml`, commonmark + URL autolinking). For `Hello https://example.com` the server emits:

```html
<p>Hello <a href="https://example.com" target="_blank" rel="noopener">https://example.com</a></p>
```

`getFirstVisibleLineHtml` walks the children of the root element in **reverse** order, keeps the **last** element whose tag is in a `displayBlockTags` set, and removes every node before it. The set incorrectly includes the inline tags `A` and `CODE`. So for the HTML above, the `<a>` is kept and the preceding text node `Hello ` is removed - which is exactly the reported symptom. The same logic also breaks:

- `text <code>inline code</code>` (text before inline code is dropped);
- `see https://x.com please` (leading text dropped, trailing kept);
- multi-line messages whose later line contains a link (preview shows the link instead of the first line);
- unordered/ordered lists (preview shows the **last** item instead of the first).

Introduced in [#24102](https://github.com/bigbluebutton/bigbluebutton/pull/24102) (commit `c19017f2ba`, 2025-10-30), which moved markdown rendering to the server and replaced the previous markdown-text first-line extraction (`messageToQuoteMarkdown` + react-markdown) with this HTML-based one. Identified by reading the function and confirmed by running the old implementation against the exact HTML shapes the server produces (results in the Evidence section). The commit is also part of the `v3.0.x` line (first released in 3.0.17), so 3.0 carries the same defect - see Risks / Notes.

## Implementation

`getFirstVisibleLineHtml` now extracts the first visible line by walking the DOM **in document order** and truncating at the first visual line break, where a line break is:

1. a `\n` inside a non-whitespace-only text node (the previews render with `white-space: pre-wrap`, so `\n` is a visual break - whitespace-only nodes between elements are markup formatting, not a break);
2. a `<br>`; or
3. the end of the first nested line-breaking (block) element, e.g. the first `<li>` of a list.

Everything after the break point is removed; inline elements (`<a>`, `<code>`, `<strong>`, ...) on the first line are kept intact. `A` and `CODE` were removed from the tag set, which now only contains actual line-breaking elements.

Files changed:

- `bigbluebutton-html5/imports/ui/components/chat/chat-graphql/service.ts` - the fix. Both previews (`chat-reply-intention` and `message-replied`) call this single function, so no component changes are needed.
- `bigbluebutton-tests/playwright/chat/chat.spec.ts`, `chat/messageActions.ts`, `core/elements.ts` - new e2e scenario `Reply to a message with text followed by a link` covering both previews (details below).

Alternatives considered:

- Fixing the HTML generation in akka-apps: discarded - the server HTML is correct; the defect is purely in the client-side first-line extraction.
- Reverting to the markdown-based quote pipeline: discarded - it would undo the whole #24102 refactor over a localized bug.

## Test Coverage

**`Reply to a message with text followed by a link`** (`bigbluebutton-tests/playwright/chat/chat.spec.ts`, implementation in `chat/messageActions.ts > replyMessageWithTextBeforeLink`)

- Objective: guarantee the reply previews keep the full first line when the original message has text before a link.
- Scenario: moderator sends `Hello https://example.com`, hovers the message, clicks reply, checks the reply intention preview, sends the reply, checks the quote inside the sent message.
- Assertions:
  1. message is sent and displayed in the public chat;
  2. message toolbar appears on hover;
  3. reply intention container appears after clicking reply;
  4. reply intention preview contains the full line `Hello https://example.com`;
  5. reply is sent as a new message (message count increases);
  6. quote inside the sent reply contains the full line `Hello https://example.com`.
- Result before the fix: fails on assertion 4 (preview shows only `https://example.com`).
- Result after the fix: passes.

The fix was additionally validated against real DOM (headless Chromium) with 12 HTML shapes the server produces - text before/after links, inline code, multi-line, hard breaks, lists, code blocks, emphasis, empty input - comparing old vs new output. The new implementation preserves the first line in all of them and keeps the previous correct behaviors unchanged.

## Manual Test Cases

| Scenario | Expected | Result |
|---|---|---|
| Reply to `Hello https://example.com` | intention preview shows `Hello https://example.com` | ✅ live env (video + DOM capture) |
| Send the reply | quote inside the reply shows `Hello https://example.com` | ✅ live env (video + DOM capture) |
| Reply to `see https://x.com please` (text on both sides) | preview shows the whole line | ✅ DOM-level check (Chromium) |
| Reply to `https://example.com hello` (link first) | preview unchanged (whole line, as before the fix) | ✅ DOM-level check (Chromium) |
| Reply to multi-line `line1` + newline + `line2` | preview shows `line1` only (unchanged behavior) | ✅ DOM-level check (Chromium) |
| Reply to a list message (`- first` / `- second`) | preview shows the first item (previously showed the last) | ✅ DOM-level check (Chromium) |
| Reply to plain message `Hello World!` (existing e2e `Reply to a message`) | unchanged, test still passes | ✅ e2e suite |
| Edit/delete/react flows (existing e2e) | unaffected | ✅ e2e suite (except pre-tagged flaky breakout-join test, unrelated - see below) |

The DOM-level checks ran the new extraction against real DOM in headless Chromium with the exact HTML shapes the server produces (12 cases, old vs new output compared).

## Evidence

### Reproduction - before the fix

What it shows: moderator sends `Hello https://example.com`, clicks reply, sends the reply. Both the reply intention preview (above the input) and the quote inside the sent reply display only `https://example.com` - the text `Hello` is dropped. Text captured from the DOM during this exact run: `{"intentionText":"https://example.com","quoteText":"https://example.com"}` (expected `Hello https://example.com`).

Animated preview below (2x speed) - click the GIF to open the MP4 (better quality, with controls):

[![Reply preview before the fix - text dropped](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-06-11/7f738aeb-c8c2-4a09-803e-17edd958f18c/before.gif)](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-06-11/e41d912c-c3db-4c9e-be3f-99f2299cd79c/before.mp4)

Timestamps in before.mp4: 0:08 message sent - 0:10 to 0:14 reply intention preview showing only the link - 0:15 to 0:20 sent reply whose quote shows only the link.

### Validation - after the fix

Same script, same environment, client rebuilt with this patch: both previews now show the full first line. Text captured from the DOM during the run: `{"intentionText":"Hello https://example.com","quoteText":"Hello https://example.com"}`.

Animated preview below (2x speed) - click the GIF to open the MP4 (better quality, with controls):

[![Reply preview after the fix - full first line](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-06-11/c6237c01-de9c-49f7-b7dc-306431d80f8e/after.gif)](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-06-11/036dd2f4-9097-443e-8566-03856ed45cae/after.mp4)

Timestamps in after.mp4: 0:08 message sent - 0:10 to 0:14 reply intention preview with text and link - 0:15 to 0:20 sent reply whose quote keeps text and link.

### Automated test runs

New scenario before the fix - fails exactly on the missing text:

```
✘ [Chromium] › chat/chat.spec.ts:206:11 › Chat › Message actions › Reply › Reply to a message with text followed by a link
  Error: should display the full first line (text and link) in the reply intention preview
  Expected substring: "Hello https://example.com"
  Received string:    "https://example.com"
```

New scenario after the fix:

```
✓ [Chromium] › chat/chat.spec.ts:206:11 › Chat › Message actions › Reply › Reply to a message with text followed by a link (8.3s)
2 passed (12.3s)
```

Full chat suite (`chat/chat.spec.ts`, 33 tests) after the fix: **31 passed, 1 skipped, 1 failed**. The only failure is `User can delete only his own messages in breakout rooms` (tagged `@flaky-3.1` by the project): it times out waiting for the breakout join menu item (`li[data-test="askToJoinRoom1"]` resolves but stays hidden) - a breakout-join UI step that runs before any chat interaction and does not involve reply previews. It fails identically when run in isolation in this environment, i.e. it is independent of this change (all 5 tests of the `Reply` describe pass, including the new one).

## Risks / Notes

- The function is only used by the two reply previews, so the blast radius is limited to them.
- Lists: the preview now shows the **first** item instead of the last - a behavior change that is part of the fix (the function's contract is "first visible line").
- The same defective function ships in the `v3.0.x` line since 3.0.17 (#24102 is in that line's history). This PR targets `v4.0.x-develop`; a 3.0 backport of the same patch is recommended as a follow-up.
- Messages rendered before the fix are unaffected (the preview is computed at render time from `messageAsHtml`; no stored data changes).
