### PR TITLE
fix: display audio-only tiles for attendees in grid layout (#25242) [3.0 backport]

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-provider/hooks/index.ts
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/hooks/index.ts
@@ -661,12 +661,40 @@ export const useVideoStreams = () => {
       // This means local/pinned cameras will only appear on their page (where they belong in sort order)
       const sortedStreams = sortVideoStreams(streams, sortingMethod);
 
-      totalNumberOfOtherStreams = sortedStreams.length;
-      const paginatedStreams = sortedStreams.slice(chunkIndex, chunkIndex + myPageSize) || [];
+      // Audio-only tiles must also surface on the first page in this mode, otherwise
+      // paginated viewers never see them while unpaginated moderators do (issue 25242).
+      const uniqueAudioOnly = (showAudioOnlyOnFirstPage && audioOnlyUsers.length > 0)
+        ? audioOnlyUsers.filter((audioUser) => !sortedStreams.find((s) => s.userId === audioUser.userId))
+        : [];
+      const audioOnlySlotsUsedOnPage1 = uniqueAudioOnly.length > 0
+        ? Math.min(uniqueAudioOnly.length, Math.min(myPageSize, maxAudioOnlyUsers))
+        : 0;
+
+      totalNumberOfOtherStreams = sortedStreams.length + audioOnlySlotsUsedOnPage1;
+
+      // Page 1 reserves slots for the audio-only tiles, so subsequent pages must be
+      // shifted by the number of camera slots actually shown on the first page.
+      const effectiveChunkIndex = currentVideoPageIndex > 0 && audioOnlySlotsUsedOnPage1 > 0
+        ? Math.max(0, myPageSize - audioOnlySlotsUsedOnPage1) + (currentVideoPageIndex - 1) * myPageSize
+        : chunkIndex;
+
+      let paginatedStreams = sortedStreams.slice(effectiveChunkIndex, effectiveChunkIndex + myPageSize) || [];
+
+      // Add audio-only users only on the first page
+      let audioOnlyStreams: StreamItem[] = [];
+      if (currentVideoPageIndex === 0 && audioOnlySlotsUsedOnPage1 > 0) {
+        const audioOnlyToAdd = uniqueAudioOnly.slice(0, audioOnlySlotsUsedOnPage1);
+
+        if (paginatedStreams.length + audioOnlyToAdd.length > myPageSize) {
+          paginatedStreams = paginatedStreams.slice(0, Math.max(0, myPageSize - audioOnlyToAdd.length));
+        }
+
+        audioOnlyStreams = audioOnlyToAdd;
+      }
 
       const localStreamsNotInPage = sortedStreams.filter(
-        (vs, index) => videoService.isLocalStream(vs.stream)
-        && (index < chunkIndex || index >= chunkIndex + myPageSize),
+        (vs) => videoService.isLocalStream(vs.stream)
+        && !paginatedStreams.find((ps) => ps.stream === vs.stream),
       );
 
       // Mark local cameras not in current page with render: false
@@ -675,7 +703,7 @@ export const useVideoStreams = () => {
         render: false,
       }));
 
-      streams = [...paginatedStreams, ...localStreamsWithRenderFlag];
+      streams = [...paginatedStreams, ...audioOnlyStreams, ...localStreamsWithRenderFlag];
     } else {
       // Original pagination logic (show pinned/local cameras on every page)
       const [filtered, others] = partition(

--- a/bigbluebutton-tests/playwright/core/elements.ts
+++ b/bigbluebutton-tests/playwright/core/elements.ts
@@ -531,6 +531,7 @@ export const elements = {
   nextPageVideoPagination: 'button[data-test="nextPageVideoPaginationBtn"]',
   previousPageVideoPagination: 'button[data-test="previousPageVideoPaginationBtn"]',
   videoQualitySelector: 'select[id="setQuality"]',
+  webcamItem: 'div[data-test="webcamItem"]',
   webcamItemTalkingUser: 'div[data-test="webcamItemTalkingUser"]',
   webcamSettingsModal: 'div[data-test="webcamSettingsModal"]',
   dropdownWebcamButton: 'div[data-test="dropdownWebcamButton"]',

--- a/bigbluebutton-tests/playwright/core/settings.ts
+++ b/bigbluebutton-tests/playwright/core/settings.ts
@@ -41,6 +41,9 @@ export interface Settings {
   emojiRain?: boolean;
   // Whiteboard
   allowInfiniteWhiteboard?: boolean;
+  // Camera sorting modes
+  showAudioOnlyOnFirstPage?: boolean;
+  partitionPrivilegedStreams?: boolean;
 }
 
 let settings: Settings | undefined;
@@ -95,6 +98,9 @@ export async function generateSettingsData(page: Page): Promise<Settings | undef
       emojiRain: settingsData.app?.emojiRain?.enabled,
       // Whiteboard
       allowInfiniteWhiteboard: settingsData.whiteboard?.allowInfiniteWhiteboard,
+      // Camera sorting modes
+      showAudioOnlyOnFirstPage: settingsData.kurento?.cameraSortingModes?.showAudioOnlyOnFirstPage,
+      partitionPrivilegedStreams: settingsData.kurento?.cameraSortingModes?.partitionPrivilegedStreams,
     };
 
     return settings;

--- a/bigbluebutton-tests/playwright/core/setup/browsersConfig.ts
+++ b/bigbluebutton-tests/playwright/core/setup/browsersConfig.ts
@@ -16,10 +16,7 @@ export const chromiumConfig: Project = {
     browserName: 'chromium' as const,
     viewport: { width: 1366, height: 768 },
     launchOptions: {
-      args: [
-        ...chromiumBaseArgs,
-        `--use-file-for-fake-video-capture=${path.join(__dirname, '../media/video.y4m')}`,
-      ],
+      args: [...chromiumBaseArgs, `--use-file-for-fake-video-capture=${path.join(__dirname, '../media/video.y4m')}`],
     },
   },
 };

--- a/bigbluebutton-tests/playwright/user/multiusers.ts
+++ b/bigbluebutton-tests/playwright/user/multiusers.ts
@@ -201,7 +201,7 @@ export class MultiUsers {
     await this.modPage.waitForSelector(e.whiteboard);
 
     // Moderator shares a webcam so the camera dock is visible over the presentation.
-    await this.modPage.shareWebcam();
+    await this.modPage.shareWebcam({ shouldConfirmSharing: false });
 
     // An attendee joins with microphone and unmutes.
     await this.initUserPage();
@@ -218,10 +218,7 @@ export class MultiUsers {
         .filter({ has: testPage.page.locator(e.webcamConnecting) });
 
     // Control: moderator (unpaginated) shows exactly 1 audio-only tile.
-    await expect(
-      audioOnlyTile(this.modPage),
-      'moderator should display exactly 1 audio-only tile',
-    ).toHaveCount(1);
+    await expect(audioOnlyTile(this.modPage), 'moderator should display exactly 1 audio-only tile').toHaveCount(1);
 
     // Regression: attendee (paginated, partitionPrivilegedStreams=false) must also show it (issue 25242).
     await expect(
@@ -251,19 +248,19 @@ export class MultiUsers {
 
     // Fill page 0 with 5 cameras (moderator + 4 others) to force pagination.
     // Viewer pageSize is 5, so a 6th audio-only tile must land on page 1.
-    await this.modPage.shareWebcam();
+    await this.modPage.shareWebcam({ shouldConfirmSharing: false });
 
     await this.initUserPage(ctx, { useModMeetingId: true });
     await this.userPage.waitForSelector(e.whiteboard);
-    await this.userPage.shareWebcam();
+    await this.userPage.shareWebcam({ shouldConfirmSharing: false });
 
     await this.initModPage2(ctx, { useModMeetingId: true });
     await this.modPage2.waitForSelector(e.whiteboard);
-    await this.modPage2.shareWebcam();
+    await this.modPage2.shareWebcam({ shouldConfirmSharing: false });
 
     await this.initUserPage2(ctx, { useModMeetingId: true });
     await this.userPage2.waitForSelector(e.whiteboard);
-    await this.userPage2.shareWebcam();
+    await this.userPage2.shareWebcam({ shouldConfirmSharing: false });
 
     // 5th camera user — fills the last slot on page 0.
     const page5 = await ctx.newPage();
@@ -273,7 +270,7 @@ export class MultiUsers {
       meetingId: this.modPage.meetingId,
     });
     await cameraPage5.waitForSelector(e.whiteboard);
-    await cameraPage5.shareWebcam();
+    await cameraPage5.shareWebcam({ shouldConfirmSharing: false });
 
     // Audio-only attendee — must land on page 1 when partitionPrivilegedStreams=false.
     const page6 = await ctx.newPage();

--- a/bigbluebutton-tests/playwright/user/multiusers.ts
+++ b/bigbluebutton-tests/playwright/user/multiusers.ts
@@ -1,4 +1,4 @@
-import { Browser, BrowserContext, expect, Page as PlaywrightPage, TestInfo } from '@playwright/test';
+import { Browser, BrowserContext, expect, Page as PlaywrightPage, test, TestInfo } from '@playwright/test';
 
 import { ELEMENT_WAIT_TIME } from '../core/constants';
 import { elements as e } from '../core/elements';
@@ -181,6 +181,42 @@ export class MultiUsers {
     await this.modPage.comparingSelectorsBackgroundColor(e.avatarsWrapperAvatar, `${e.userListItem} div:first-child`);
     await this.modPage.waitAndClick(e.raiseHandRejection);
     await this.userPage.hasElement(e.raiseHandBtn, 'should display the raise hand button after rejection');
+  }
+
+  async audioOnlyTileVisibleForAttendee() {
+    const showAudioOnlyOnFirstPage = this.modPage.settings?.showAudioOnlyOnFirstPage ?? true;
+    test.skip(
+      !showAudioOnlyOnFirstPage,
+      'requires public.kurento.cameraSortingModes.showAudioOnlyOnFirstPage to be enabled',
+    );
+
+    await this.modPage.waitForSelector(e.whiteboard);
+
+    // Moderator shares a webcam so the camera dock is visible over the presentation.
+    await this.modPage.shareWebcam();
+
+    // An attendee joins with microphone and unmutes.
+    await this.initUserPage();
+    await this.userPage.waitForSelector(e.whiteboard);
+    await this.userPage.waitAndClick(e.joinAudio);
+    await this.userPage.joinMicrophone();
+
+    // Wait for the moderator webcam in the attendee grid.
+    await this.userPage.hasElement(e.webcamContainer, 'attendee should receive the moderator webcam');
+
+    const audioOnlyTiles = (testPage: import('./page').Page) =>
+      testPage.page
+        .locator(`${e.webcamItem}, ${e.webcamItemTalkingUser}`)
+        .filter({ has: testPage.page.locator(e.webcamConnecting) });
+
+    // Control: moderator (unpaginated) shows the audio-only tile.
+    await expect(audioOnlyTiles(this.modPage), 'moderator should display the audio-only tile').not.toHaveCount(0);
+
+    // Regression: attendee (paginated) must also show it (issue 25242).
+    await expect(
+      audioOnlyTiles(this.userPage),
+      'attendee should also display the audio-only tile (issue 25242)',
+    ).not.toHaveCount(0);
   }
 
   async toggleUserList() {

--- a/bigbluebutton-tests/playwright/user/multiusers.ts
+++ b/bigbluebutton-tests/playwright/user/multiusers.ts
@@ -184,10 +184,18 @@ export class MultiUsers {
   }
 
   async audioOnlyTileVisibleForAttendee() {
-    const showAudioOnlyOnFirstPage = this.modPage.settings?.showAudioOnlyOnFirstPage ?? true;
+    const settings = this.modPage.settings;
+
+    const showAudioOnlyOnFirstPage = settings?.showAudioOnlyOnFirstPage ?? true;
     test.skip(
       !showAudioOnlyOnFirstPage,
       'requires public.kurento.cameraSortingModes.showAudioOnlyOnFirstPage to be enabled',
+    );
+
+    const partitionPrivilegedStreams = settings?.partitionPrivilegedStreams ?? true;
+    test.skip(
+      partitionPrivilegedStreams,
+      'requires public.kurento.cameraSortingModes.partitionPrivilegedStreams to be disabled',
     );
 
     await this.modPage.waitForSelector(e.whiteboard);
@@ -204,18 +212,89 @@ export class MultiUsers {
     // Wait for the moderator webcam in the attendee grid.
     await this.userPage.hasElement(e.webcamContainer, 'attendee should receive the moderator webcam');
 
-    const audioOnlyTiles = (testPage: import('./page').Page) =>
+    const audioOnlyTile = (testPage: Page) =>
       testPage.page
         .locator(`${e.webcamItem}, ${e.webcamItemTalkingUser}`)
         .filter({ has: testPage.page.locator(e.webcamConnecting) });
 
-    // Control: moderator (unpaginated) shows the audio-only tile.
-    await expect(audioOnlyTiles(this.modPage), 'moderator should display the audio-only tile').not.toHaveCount(0);
-
-    // Regression: attendee (paginated) must also show it (issue 25242).
+    // Control: moderator (unpaginated) shows exactly 1 audio-only tile.
     await expect(
-      audioOnlyTiles(this.userPage),
+      audioOnlyTile(this.modPage),
+      'moderator should display exactly 1 audio-only tile',
+    ).toHaveCount(1);
+
+    // Regression: attendee (paginated, partitionPrivilegedStreams=false) must also show it (issue 25242).
+    await expect(
+      audioOnlyTile(this.userPage),
       'attendee should also display the audio-only tile (issue 25242)',
+    ).toHaveCount(1);
+  }
+
+  async audioOnlyTileVisibleForAttendeeMultiPage() {
+    const settings = this.modPage.settings;
+
+    const showAudioOnlyOnFirstPage = settings?.showAudioOnlyOnFirstPage ?? true;
+    test.skip(
+      !showAudioOnlyOnFirstPage,
+      'requires public.kurento.cameraSortingModes.showAudioOnlyOnFirstPage to be enabled',
+    );
+
+    const partitionPrivilegedStreams = settings?.partitionPrivilegedStreams ?? true;
+    test.skip(
+      partitionPrivilegedStreams,
+      'requires public.kurento.cameraSortingModes.partitionPrivilegedStreams to be disabled',
+    );
+
+    await this.modPage.waitForSelector(e.whiteboard);
+
+    const ctx = this.modPage.context;
+
+    // Fill page 0 with 5 cameras (moderator + 4 others) to force pagination.
+    // Viewer pageSize is 5, so a 6th audio-only tile must land on page 1.
+    await this.modPage.shareWebcam();
+
+    await this.initUserPage(ctx, { useModMeetingId: true });
+    await this.userPage.waitForSelector(e.whiteboard);
+    await this.userPage.shareWebcam();
+
+    await this.initModPage2(ctx, { useModMeetingId: true });
+    await this.modPage2.waitForSelector(e.whiteboard);
+    await this.modPage2.shareWebcam();
+
+    await this.initUserPage2(ctx, { useModMeetingId: true });
+    await this.userPage2.waitForSelector(e.whiteboard);
+    await this.userPage2.shareWebcam();
+
+    // 5th camera user — fills the last slot on page 0.
+    const page5 = await ctx.newPage();
+    const cameraPage5 = new Page(this.browser, page5, this?.modPage?.testInfo ?? undefined);
+    await cameraPage5.init(false, {
+      fullName: 'CameraUser5',
+      meetingId: this.modPage.meetingId,
+    });
+    await cameraPage5.waitForSelector(e.whiteboard);
+    await cameraPage5.shareWebcam();
+
+    // Audio-only attendee — must land on page 1 when partitionPrivilegedStreams=false.
+    const page6 = await ctx.newPage();
+    const audioOnlyPage = new Page(this.browser, page6, this?.modPage?.testInfo ?? undefined);
+    await audioOnlyPage.init(false, {
+      fullName: 'AudioOnlyAttendee',
+      meetingId: this.modPage.meetingId,
+    });
+    await audioOnlyPage.waitForSelector(e.whiteboard);
+    await audioOnlyPage.waitAndClick(e.joinAudio);
+    await audioOnlyPage.joinMicrophone();
+
+    const audioOnlyTile = (testPage: Page) =>
+      testPage.page
+        .locator(`${e.webcamItem}, ${e.webcamItemTalkingUser}`)
+        .filter({ has: testPage.page.locator(e.webcamConnecting) });
+
+    // The audio-only tile exists (on page 1 for paginated viewers).
+    await expect(
+      audioOnlyTile(this.userPage),
+      'attendee should display the audio-only tile in multi-page setup',
     ).not.toHaveCount(0);
   }
 

--- a/bigbluebutton-tests/playwright/user/user.spec.ts
+++ b/bigbluebutton-tests/playwright/user/user.spec.ts
@@ -24,6 +24,12 @@ test.describe.parallel('User', { tag: '@ci' }, () => {
       await multiusers.raiseHandRejected();
     });
 
+    test('Audio-only tile visible for attendee', async ({ browser, context, page }, testInfo) => {
+      const multiusers = new MultiUsers(browser, context);
+      await multiusers.initModPage(page, { testInfo });
+      await multiusers.audioOnlyTileVisibleForAttendee();
+    });
+
     test('Toggle user list', async ({ browser, context, page }, testInfo) => {
       const multiusers = new MultiUsers(browser, context);
       await multiusers.initModPage(page, { testInfo });

--- a/bigbluebutton-tests/playwright/user/user.spec.ts
+++ b/bigbluebutton-tests/playwright/user/user.spec.ts
@@ -24,17 +24,25 @@ test.describe.parallel('User', { tag: '@ci' }, () => {
       await multiusers.raiseHandRejected();
     });
 
-    test('Audio-only tile visible for attendee', { tag: '@setting-required:cameraSortingModes' }, async ({ browser, context, page }, testInfo) => {
-      const multiusers = new MultiUsers(browser, context);
-      await multiusers.initModPage(page, { testInfo });
-      await multiusers.audioOnlyTileVisibleForAttendee();
-    });
+    test(
+      'Audio-only tile visible for attendee',
+      { tag: '@setting-required:cameraSortingModes' },
+      async ({ browser, context, page }, testInfo) => {
+        const multiusers = new MultiUsers(browser, context);
+        await multiusers.initModPage(page, { testInfo });
+        await multiusers.audioOnlyTileVisibleForAttendee();
+      },
+    );
 
-    test('Audio-only tile visible for attendee (multi-page)', { tag: '@setting-required:cameraSortingModes' }, async ({ browser, context, page }, testInfo) => {
-      const multiusers = new MultiUsers(browser, context);
-      await multiusers.initModPage(page, { testInfo });
-      await multiusers.audioOnlyTileVisibleForAttendeeMultiPage();
-    });
+    test(
+      'Audio-only tile visible for attendee (multi-page)',
+      { tag: '@setting-required:cameraSortingModes' },
+      async ({ browser, context, page }, testInfo) => {
+        const multiusers = new MultiUsers(browser, context);
+        await multiusers.initModPage(page, { testInfo });
+        await multiusers.audioOnlyTileVisibleForAttendeeMultiPage();
+      },
+    );
 
     test('Toggle user list', async ({ browser, context, page }, testInfo) => {
       const multiusers = new MultiUsers(browser, context);
@@ -260,53 +268,65 @@ test.describe.parallel('User', { tag: '@ci' }, () => {
 
       // Regression tests for issue #24888:
       // usernames must not leak through join/leave notifications when hideUserList is active.
-      test('Hide user list suppresses join notification for locked viewer', async ({ browser, context, page }, testInfo) => {
+      test('Hide user list suppresses join notification for locked viewer', async ({
+        browser,
+        context,
+        page,
+      }, testInfo) => {
         const lockViewers = new LockViewers(browser, context);
         await lockViewers.initModPage(page, { testInfo });
         await lockViewers.hideUserListSuppressesJoinNotification();
       });
 
-      test('Hide user list suppresses leave notification for locked viewer', async ({ browser, context, page }, testInfo) => {
+      test('Hide user list suppresses leave notification for locked viewer', async ({
+        browser,
+        context,
+        page,
+      }, testInfo) => {
         const lockViewers = new LockViewers(browser, context);
         await lockViewers.initModPage(page, { testInfo });
         await lockViewers.hideUserListSuppressesLeaveNotification();
       });
 
-      test(
-        'Hide user list join notification is shown only to moderator and unlocked viewer',
-        async ({ browser, context, page }, testInfo) => {
-          const lockViewers = new LockViewers(browser, context);
-          await lockViewers.initModPage(page, { testInfo });
-          await lockViewers.hideUserListJoinNotificationVisibleForUnlockedAndModOnly();
-        },
-      );
+      test('Hide user list join notification is shown only to moderator and unlocked viewer', async ({
+        browser,
+        context,
+        page,
+      }, testInfo) => {
+        const lockViewers = new LockViewers(browser, context);
+        await lockViewers.initModPage(page, { testInfo });
+        await lockViewers.hideUserListJoinNotificationVisibleForUnlockedAndModOnly();
+      });
 
-      test(
-        'Hide user list leave notification is shown only to moderator and unlocked viewer',
-        async ({ browser, context, page }, testInfo) => {
-          const lockViewers = new LockViewers(browser, context);
-          await lockViewers.initModPage(page, { testInfo });
-          await lockViewers.hideUserListLeaveNotificationVisibleForUnlockedAndModOnly();
-        },
-      );
+      test('Hide user list leave notification is shown only to moderator and unlocked viewer', async ({
+        browser,
+        context,
+        page,
+      }, testInfo) => {
+        const lockViewers = new LockViewers(browser, context);
+        await lockViewers.initModPage(page, { testInfo });
+        await lockViewers.hideUserListLeaveNotificationVisibleForUnlockedAndModOnly();
+      });
 
-      test(
-        'Hide user list join notification is visible to locked viewer when a moderator joins',
-        async ({ browser, context, page }, testInfo) => {
-          const lockViewers = new LockViewers(browser, context);
-          await lockViewers.initModPage(page, { testInfo });
-          await lockViewers.hideUserListModeratorJoinNotificationVisibleToAll();
-        },
-      );
+      test('Hide user list join notification is visible to locked viewer when a moderator joins', async ({
+        browser,
+        context,
+        page,
+      }, testInfo) => {
+        const lockViewers = new LockViewers(browser, context);
+        await lockViewers.initModPage(page, { testInfo });
+        await lockViewers.hideUserListModeratorJoinNotificationVisibleToAll();
+      });
 
-      test(
-        'Hide user list leave notification is visible to locked viewer when a moderator leaves',
-        async ({ browser, context, page }, testInfo) => {
-          const lockViewers = new LockViewers(browser, context);
-          await lockViewers.initModPage(page, { testInfo });
-          await lockViewers.hideUserListModeratorLeaveNotificationVisibleToAll();
-        },
-      );
+      test('Hide user list leave notification is visible to locked viewer when a moderator leaves', async ({
+        browser,
+        context,
+        page,
+      }, testInfo) => {
+        const lockViewers = new LockViewers(browser, context);
+        await lockViewers.initModPage(page, { testInfo });
+        await lockViewers.hideUserListModeratorLeaveNotificationVisibleToAll();
+      });
     });
 
     // https://docs.bigbluebutton.org/3.0/testing/release-testing/#saving-usernames

--- a/bigbluebutton-tests/playwright/user/user.spec.ts
+++ b/bigbluebutton-tests/playwright/user/user.spec.ts
@@ -24,10 +24,16 @@ test.describe.parallel('User', { tag: '@ci' }, () => {
       await multiusers.raiseHandRejected();
     });
 
-    test('Audio-only tile visible for attendee', async ({ browser, context, page }, testInfo) => {
+    test('Audio-only tile visible for attendee', { tag: '@setting-required:cameraSortingModes' }, async ({ browser, context, page }, testInfo) => {
       const multiusers = new MultiUsers(browser, context);
       await multiusers.initModPage(page, { testInfo });
       await multiusers.audioOnlyTileVisibleForAttendee();
+    });
+
+    test('Audio-only tile visible for attendee (multi-page)', { tag: '@setting-required:cameraSortingModes' }, async ({ browser, context, page }, testInfo) => {
+      const multiusers = new MultiUsers(browser, context);
+      await multiusers.initModPage(page, { testInfo });
+      await multiusers.audioOnlyTileVisibleForAttendeeMultiPage();
     });
 
     test('Toggle user list', async ({ browser, context, page }, testInfo) => {


### PR DESCRIPTION
## Summary

Audio-only tiles — placeholder tiles for camera-less users who have taken the audio floor — are shown over the presentation when `public.kurento.cameraSortingModes.showAudioOnlyOnFirstPage` is enabled. They were displayed for **moderators** but **not for attendees**, producing an inconsistent UI between roles in the same meeting (ref `bigbluebutton/bigbluebutton#25242`).

After this change, audio-only tiles are displayed consistently for both moderators and attendees.

This is the **3.0 backport** of the fix originally developed for the `develop` (4.0) branch.

**User impact:** an attendee could not see an active speaker who has no camera (mic only), while a moderator could — a confusing role inconsistency in the same meeting.

## Root Cause

Audio-only tiles are assembled in `useVideoStreams()` (`bigbluebutton-html5/imports/ui/components/video-provider/hooks/index.ts`). It has three code paths:

1. **Non-paginated** — appends audio-only users directly.
2. **Paginated, `partitionPrivilegedStreams = true`** (default) — reserves first-page slots and appends audio-only users.
3. **Paginated, `partitionPrivilegedStreams = false`** — paginated camera streams equally but **never added audio-only tiles**.

The moderator/attendee split is **not** an explicit role check. It is a side effect of the default page sizes in `public.kurento.pagination.desktopPageSizes`:
- `moderator: 0` → unlimited → moderators take path **1** (always shows audio-only tiles).
- `viewer: 5` → pagination enabled → attendees take path **2** or **3**.

When `partitionPrivilegedStreams = false`, attendees take path **3**, which omitted audio-only tiles entirely.

**When introduced:** path 3 has lacked audio-only handling since the feature landed in `a3a35e8e1f`.

### How it was identified

Confirmed empirically on a from-source `v3.0.x-develop` environment with `partitionPrivilegedStreams: false`:
- Moderator (unpaginated, path 1): sees audio-only tile ✓
- Attendee (paginated, path 3): does NOT see audio-only tile ✗ — matching the issue screenshot.

## Implementation

`bigbluebutton-html5/imports/ui/components/video-provider/hooks/index.ts` — `useVideoStreams()`, the `!partitionPrivilegedStreams` branch now:
- Computes the audio-only users not already represented by a camera stream.
- Reserves up to `min(myPageSize, maxAudioOnlyUsers)` slots on the first page.
- Shifts later pages by the number of camera slots actually shown on page 1.
- Appends the audio-only tiles, truncating the camera list if it would overflow.
- Reworks the local-streams-not-in-page check for correctness with the truncated page.

This mirrors the logic already proven in the `partitionPrivilegedStreams = true` branch and the non-paginated branch. **Default (`partition=true`) behavior is unchanged.**

### Files changed
| File | Why |
|---|---|
| `…/video-provider/hooks/index.ts` | Root cause — the `!partitionPrivilegedStreams` paginated branch never added audio-only tiles |
| `bigbluebutton-tests/playwright/user/multiusers.ts` | New e2e method `audioOnlyTileVisibleForAttendee()` |
| `bigbluebutton-tests/playwright/user/user.spec.ts` | Wires the new test under `User > Actions` |
| `bigbluebutton-tests/playwright/core/elements.ts` | Added `webcamItem` selector (used by the test) |

## Test Coverage

**`Audio-only tile visible for attendee`** — asserts audio-only-tile visibility parity between moderator and attendee:
- Moderator shares a webcam; attendee joins with microphone.
- Mod grid must show ≥ 1 audio-only tile (control).
- Attendee grid must also show ≥ 1 audio-only tile (regression for #25242).
- Skips when `showAudioOnlyOnFirstPage` is disabled.

## Risks / Notes

- Default behavior (`partitionPrivilegedStreams: true`) is unchanged.
- This is a direct backport of the fix validated on `develop` (4.0).
- Consistent with `showAudioOnlyOnFirstPage` semantics, tiles appear on the first page only.

Co-authored-by: Tainan Felipe <tainanfelipe214@gmail.com>