### PR TITLE
test: fix audio-only tile test to cover the intended code path

### DIFF
--- a/bigbluebutton-tests/playwright/core/settings.ts
+++ b/bigbluebutton-tests/playwright/core/settings.ts
@@ -41,6 +41,9 @@ export interface Settings {
   emojiRain?: boolean;
   // Whiteboard
   allowInfiniteWhiteboard?: boolean;
+  // Camera sorting modes
+  showAudioOnlyOnFirstPage?: boolean;
+  partitionPrivilegedStreams?: boolean;
 }
 
 let settings: Settings | undefined;
@@ -95,6 +98,9 @@ export async function generateSettingsData(page: Page): Promise<Settings | undef
       emojiRain: settingsData.app?.emojiRain?.enabled,
       // Whiteboard
       allowInfiniteWhiteboard: settingsData.whiteboard?.allowInfiniteWhiteboard,
+      // Camera sorting modes
+      showAudioOnlyOnFirstPage: settingsData.kurento?.cameraSortingModes?.showAudioOnlyOnFirstPage,
+      partitionPrivilegedStreams: settingsData.kurento?.cameraSortingModes?.partitionPrivilegedStreams,
     };
 
     return settings;

--- a/bigbluebutton-tests/playwright/core/setup/browsersConfig.ts
+++ b/bigbluebutton-tests/playwright/core/setup/browsersConfig.ts
@@ -16,10 +16,7 @@ export const chromiumConfig: Project = {
     browserName: 'chromium' as const,
     viewport: { width: 1366, height: 768 },
     launchOptions: {
-      args: [
-        ...chromiumBaseArgs,
-        `--use-file-for-fake-video-capture=${path.join(__dirname, '../media/video.y4m')}`,
-      ],
+      args: [...chromiumBaseArgs, `--use-file-for-fake-video-capture=${path.join(__dirname, '../media/video.y4m')}`],
     },
   },
 };

--- a/bigbluebutton-tests/playwright/user/multiusers.ts
+++ b/bigbluebutton-tests/playwright/user/multiusers.ts
@@ -201,7 +201,7 @@ export class MultiUsers {
     await this.modPage.waitForSelector(e.whiteboard);
 
     // Moderator shares a webcam so the camera dock is visible over the presentation.
-    await this.modPage.shareWebcam();
+    await this.modPage.shareWebcam({ shouldConfirmSharing: false });
 
     // An attendee joins with microphone and unmutes.
     await this.initUserPage();
@@ -218,10 +218,7 @@ export class MultiUsers {
         .filter({ has: testPage.page.locator(e.webcamConnecting) });
 
     // Control: moderator (unpaginated) shows exactly 1 audio-only tile.
-    await expect(
-      audioOnlyTile(this.modPage),
-      'moderator should display exactly 1 audio-only tile',
-    ).toHaveCount(1);
+    await expect(audioOnlyTile(this.modPage), 'moderator should display exactly 1 audio-only tile').toHaveCount(1);
 
     // Regression: attendee (paginated, partitionPrivilegedStreams=false) must also show it (issue 25242).
     await expect(
@@ -251,19 +248,19 @@ export class MultiUsers {
 
     // Fill page 0 with 5 cameras (moderator + 4 others) to force pagination.
     // Viewer pageSize is 5, so a 6th audio-only tile must land on page 1.
-    await this.modPage.shareWebcam();
+    await this.modPage.shareWebcam({ shouldConfirmSharing: false });
 
     await this.initUserPage(ctx, { useModMeetingId: true });
     await this.userPage.waitForSelector(e.whiteboard);
-    await this.userPage.shareWebcam();
+    await this.userPage.shareWebcam({ shouldConfirmSharing: false });
 
     await this.initModPage2(ctx, { useModMeetingId: true });
     await this.modPage2.waitForSelector(e.whiteboard);
-    await this.modPage2.shareWebcam();
+    await this.modPage2.shareWebcam({ shouldConfirmSharing: false });
 
     await this.initUserPage2(ctx, { useModMeetingId: true });
     await this.userPage2.waitForSelector(e.whiteboard);
-    await this.userPage2.shareWebcam();
+    await this.userPage2.shareWebcam({ shouldConfirmSharing: false });
 
     // 5th camera user — fills the last slot on page 0.
     const page5 = await ctx.newPage();
@@ -273,7 +270,7 @@ export class MultiUsers {
       meetingId: this.modPage.meetingId,
     });
     await cameraPage5.waitForSelector(e.whiteboard);
-    await cameraPage5.shareWebcam();
+    await cameraPage5.shareWebcam({ shouldConfirmSharing: false });
 
     // Audio-only attendee — must land on page 1 when partitionPrivilegedStreams=false.
     const page6 = await ctx.newPage();

--- a/bigbluebutton-tests/playwright/user/multiusers.ts
+++ b/bigbluebutton-tests/playwright/user/multiusers.ts
@@ -184,10 +184,18 @@ export class MultiUsers {
   }
 
   async audioOnlyTileVisibleForAttendee() {
-    const showAudioOnlyOnFirstPage = this.modPage.settings?.showAudioOnlyOnFirstPage ?? true;
+    const settings = this.modPage.settings;
+
+    const showAudioOnlyOnFirstPage = settings?.showAudioOnlyOnFirstPage ?? true;
     test.skip(
       !showAudioOnlyOnFirstPage,
       'requires public.kurento.cameraSortingModes.showAudioOnlyOnFirstPage to be enabled',
+    );
+
+    const partitionPrivilegedStreams = settings?.partitionPrivilegedStreams ?? true;
+    test.skip(
+      partitionPrivilegedStreams,
+      'requires public.kurento.cameraSortingModes.partitionPrivilegedStreams to be disabled',
     );
 
     await this.modPage.waitForSelector(e.whiteboard);
@@ -204,18 +212,89 @@ export class MultiUsers {
     // Wait for the moderator webcam in the attendee grid.
     await this.userPage.hasElement(e.webcamContainer, 'attendee should receive the moderator webcam');
 
-    const audioOnlyTiles = (testPage: import('./page').Page) =>
+    const audioOnlyTile = (testPage: Page) =>
       testPage.page
         .locator(`${e.webcamItem}, ${e.webcamItemTalkingUser}`)
         .filter({ has: testPage.page.locator(e.webcamConnecting) });
 
-    // Control: moderator (unpaginated) shows the audio-only tile.
-    await expect(audioOnlyTiles(this.modPage), 'moderator should display the audio-only tile').not.toHaveCount(0);
-
-    // Regression: attendee (paginated) must also show it (issue 25242).
+    // Control: moderator (unpaginated) shows exactly 1 audio-only tile.
     await expect(
-      audioOnlyTiles(this.userPage),
+      audioOnlyTile(this.modPage),
+      'moderator should display exactly 1 audio-only tile',
+    ).toHaveCount(1);
+
+    // Regression: attendee (paginated, partitionPrivilegedStreams=false) must also show it (issue 25242).
+    await expect(
+      audioOnlyTile(this.userPage),
       'attendee should also display the audio-only tile (issue 25242)',
+    ).toHaveCount(1);
+  }
+
+  async audioOnlyTileVisibleForAttendeeMultiPage() {
+    const settings = this.modPage.settings;
+
+    const showAudioOnlyOnFirstPage = settings?.showAudioOnlyOnFirstPage ?? true;
+    test.skip(
+      !showAudioOnlyOnFirstPage,
+      'requires public.kurento.cameraSortingModes.showAudioOnlyOnFirstPage to be enabled',
+    );
+
+    const partitionPrivilegedStreams = settings?.partitionPrivilegedStreams ?? true;
+    test.skip(
+      partitionPrivilegedStreams,
+      'requires public.kurento.cameraSortingModes.partitionPrivilegedStreams to be disabled',
+    );
+
+    await this.modPage.waitForSelector(e.whiteboard);
+
+    const ctx = this.modPage.context;
+
+    // Fill page 0 with 5 cameras (moderator + 4 others) to force pagination.
+    // Viewer pageSize is 5, so a 6th audio-only tile must land on page 1.
+    await this.modPage.shareWebcam();
+
+    await this.initUserPage(ctx, { useModMeetingId: true });
+    await this.userPage.waitForSelector(e.whiteboard);
+    await this.userPage.shareWebcam();
+
+    await this.initModPage2(ctx, { useModMeetingId: true });
+    await this.modPage2.waitForSelector(e.whiteboard);
+    await this.modPage2.shareWebcam();
+
+    await this.initUserPage2(ctx, { useModMeetingId: true });
+    await this.userPage2.waitForSelector(e.whiteboard);
+    await this.userPage2.shareWebcam();
+
+    // 5th camera user — fills the last slot on page 0.
+    const page5 = await ctx.newPage();
+    const cameraPage5 = new Page(this.browser, page5, this?.modPage?.testInfo ?? undefined);
+    await cameraPage5.init(false, {
+      fullName: 'CameraUser5',
+      meetingId: this.modPage.meetingId,
+    });
+    await cameraPage5.waitForSelector(e.whiteboard);
+    await cameraPage5.shareWebcam();
+
+    // Audio-only attendee — must land on page 1 when partitionPrivilegedStreams=false.
+    const page6 = await ctx.newPage();
+    const audioOnlyPage = new Page(this.browser, page6, this?.modPage?.testInfo ?? undefined);
+    await audioOnlyPage.init(false, {
+      fullName: 'AudioOnlyAttendee',
+      meetingId: this.modPage.meetingId,
+    });
+    await audioOnlyPage.waitForSelector(e.whiteboard);
+    await audioOnlyPage.waitAndClick(e.joinAudio);
+    await audioOnlyPage.joinMicrophone();
+
+    const audioOnlyTile = (testPage: Page) =>
+      testPage.page
+        .locator(`${e.webcamItem}, ${e.webcamItemTalkingUser}`)
+        .filter({ has: testPage.page.locator(e.webcamConnecting) });
+
+    // The audio-only tile exists (on page 1 for paginated viewers).
+    await expect(
+      audioOnlyTile(this.userPage),
+      'attendee should display the audio-only tile in multi-page setup',
     ).not.toHaveCount(0);
   }
 

--- a/bigbluebutton-tests/playwright/user/user.spec.ts
+++ b/bigbluebutton-tests/playwright/user/user.spec.ts
@@ -24,17 +24,25 @@ test.describe.parallel('User', { tag: '@ci' }, () => {
       await multiusers.raiseHandRejected();
     });
 
-    test('Audio-only tile visible for attendee', { tag: '@setting-required:cameraSortingModes' }, async ({ browser, context, page }, testInfo) => {
-      const multiusers = new MultiUsers(browser, context);
-      await multiusers.initModPage(page, { testInfo });
-      await multiusers.audioOnlyTileVisibleForAttendee();
-    });
+    test(
+      'Audio-only tile visible for attendee',
+      { tag: '@setting-required:cameraSortingModes' },
+      async ({ browser, context, page }, testInfo) => {
+        const multiusers = new MultiUsers(browser, context);
+        await multiusers.initModPage(page, { testInfo });
+        await multiusers.audioOnlyTileVisibleForAttendee();
+      },
+    );
 
-    test('Audio-only tile visible for attendee (multi-page)', { tag: '@setting-required:cameraSortingModes' }, async ({ browser, context, page }, testInfo) => {
-      const multiusers = new MultiUsers(browser, context);
-      await multiusers.initModPage(page, { testInfo });
-      await multiusers.audioOnlyTileVisibleForAttendeeMultiPage();
-    });
+    test(
+      'Audio-only tile visible for attendee (multi-page)',
+      { tag: '@setting-required:cameraSortingModes' },
+      async ({ browser, context, page }, testInfo) => {
+        const multiusers = new MultiUsers(browser, context);
+        await multiusers.initModPage(page, { testInfo });
+        await multiusers.audioOnlyTileVisibleForAttendeeMultiPage();
+      },
+    );
 
     test('Toggle user list', async ({ browser, context, page }, testInfo) => {
       const multiusers = new MultiUsers(browser, context);
@@ -260,53 +268,65 @@ test.describe.parallel('User', { tag: '@ci' }, () => {
 
       // Regression tests for issue #24888:
       // usernames must not leak through join/leave notifications when hideUserList is active.
-      test('Hide user list suppresses join notification for locked viewer', async ({ browser, context, page }, testInfo) => {
+      test('Hide user list suppresses join notification for locked viewer', async ({
+        browser,
+        context,
+        page,
+      }, testInfo) => {
         const lockViewers = new LockViewers(browser, context);
         await lockViewers.initModPage(page, { testInfo });
         await lockViewers.hideUserListSuppressesJoinNotification();
       });
 
-      test('Hide user list suppresses leave notification for locked viewer', async ({ browser, context, page }, testInfo) => {
+      test('Hide user list suppresses leave notification for locked viewer', async ({
+        browser,
+        context,
+        page,
+      }, testInfo) => {
         const lockViewers = new LockViewers(browser, context);
         await lockViewers.initModPage(page, { testInfo });
         await lockViewers.hideUserListSuppressesLeaveNotification();
       });
 
-      test(
-        'Hide user list join notification is shown only to moderator and unlocked viewer',
-        async ({ browser, context, page }, testInfo) => {
-          const lockViewers = new LockViewers(browser, context);
-          await lockViewers.initModPage(page, { testInfo });
-          await lockViewers.hideUserListJoinNotificationVisibleForUnlockedAndModOnly();
-        },
-      );
+      test('Hide user list join notification is shown only to moderator and unlocked viewer', async ({
+        browser,
+        context,
+        page,
+      }, testInfo) => {
+        const lockViewers = new LockViewers(browser, context);
+        await lockViewers.initModPage(page, { testInfo });
+        await lockViewers.hideUserListJoinNotificationVisibleForUnlockedAndModOnly();
+      });
 
-      test(
-        'Hide user list leave notification is shown only to moderator and unlocked viewer',
-        async ({ browser, context, page }, testInfo) => {
-          const lockViewers = new LockViewers(browser, context);
-          await lockViewers.initModPage(page, { testInfo });
-          await lockViewers.hideUserListLeaveNotificationVisibleForUnlockedAndModOnly();
-        },
-      );
+      test('Hide user list leave notification is shown only to moderator and unlocked viewer', async ({
+        browser,
+        context,
+        page,
+      }, testInfo) => {
+        const lockViewers = new LockViewers(browser, context);
+        await lockViewers.initModPage(page, { testInfo });
+        await lockViewers.hideUserListLeaveNotificationVisibleForUnlockedAndModOnly();
+      });
 
-      test(
-        'Hide user list join notification is visible to locked viewer when a moderator joins',
-        async ({ browser, context, page }, testInfo) => {
-          const lockViewers = new LockViewers(browser, context);
-          await lockViewers.initModPage(page, { testInfo });
-          await lockViewers.hideUserListModeratorJoinNotificationVisibleToAll();
-        },
-      );
+      test('Hide user list join notification is visible to locked viewer when a moderator joins', async ({
+        browser,
+        context,
+        page,
+      }, testInfo) => {
+        const lockViewers = new LockViewers(browser, context);
+        await lockViewers.initModPage(page, { testInfo });
+        await lockViewers.hideUserListModeratorJoinNotificationVisibleToAll();
+      });
 
-      test(
-        'Hide user list leave notification is visible to locked viewer when a moderator leaves',
-        async ({ browser, context, page }, testInfo) => {
-          const lockViewers = new LockViewers(browser, context);
-          await lockViewers.initModPage(page, { testInfo });
-          await lockViewers.hideUserListModeratorLeaveNotificationVisibleToAll();
-        },
-      );
+      test('Hide user list leave notification is visible to locked viewer when a moderator leaves', async ({
+        browser,
+        context,
+        page,
+      }, testInfo) => {
+        const lockViewers = new LockViewers(browser, context);
+        await lockViewers.initModPage(page, { testInfo });
+        await lockViewers.hideUserListModeratorLeaveNotificationVisibleToAll();
+      });
     });
 
     // https://docs.bigbluebutton.org/3.0/testing/release-testing/#saving-usernames

--- a/bigbluebutton-tests/playwright/user/user.spec.ts
+++ b/bigbluebutton-tests/playwright/user/user.spec.ts
@@ -24,10 +24,16 @@ test.describe.parallel('User', { tag: '@ci' }, () => {
       await multiusers.raiseHandRejected();
     });
 
-    test('Audio-only tile visible for attendee', async ({ browser, context, page }, testInfo) => {
+    test('Audio-only tile visible for attendee', { tag: '@setting-required:cameraSortingModes' }, async ({ browser, context, page }, testInfo) => {
       const multiusers = new MultiUsers(browser, context);
       await multiusers.initModPage(page, { testInfo });
       await multiusers.audioOnlyTileVisibleForAttendee();
+    });
+
+    test('Audio-only tile visible for attendee (multi-page)', { tag: '@setting-required:cameraSortingModes' }, async ({ browser, context, page }, testInfo) => {
+      const multiusers = new MultiUsers(browser, context);
+      await multiusers.initModPage(page, { testInfo });
+      await multiusers.audioOnlyTileVisibleForAttendeeMultiPage();
     });
 
     test('Toggle user list', async ({ browser, context, page }, testInfo) => {


### PR DESCRIPTION
## What

Fixes the test coverage issues identified in the code review of PR #56.

## Changes

### 1. Settings model (`core/settings.ts`)
- Added `showAudioOnlyOnFirstPage` and `partitionPrivilegedStreams` to the Settings interface and extraction from client settings.

### 2. Test fixes (`user/multiusers.ts`)
- **Fixed broken import:** Replaced `import('./page').Page` with the already-imported `Page` type.
- **Fixed dead skip guard:** Now reads `settings?.showAudioOnlyOnFirstPage` from `this.modPage.settings` (previously referenced a non-existent property and always evaluated to `true`).
- **Added partitionPrivilegedStreams guard:** The test now skips when `partitionPrivilegedStreams: true` (default), ensuring it only runs on the `false` branch that this PR actually modifies.
- **Tightened assertions:** Changed from `not.toHaveCount(0)` to `toHaveCount(1)` to avoid false passes from connecting camera tiles.

### 3. Multi-page test (`user/multiusers.ts` + `user/user.spec.ts`)
- Added `audioOnlyTileVisibleForAttendeeMultiPage`: fills page 0 with 5 cameras so the 6th participant (audio-only) must land on page 1, exercising the `effectiveChunkIndex` page>0 path.
- Both tests tagged with `@setting-required:cameraSortingModes` to exclude from default CI runs.

## Not addressed (follow-up)

- The optional `effectiveChunkIndex` simplification mentioned in the review (match sibling branch's `chunkIndex - audioOnlySlotsUsedOnPage1`) — this is a production code change in a separate file from the test fixes. Left for a follow-up if desired.