### PR TITLE
test(reconnection): webcam virtual-background dropped after reconnection (#25266)

### DIFF
--- a/bigbluebutton-tests/playwright/reconnection/util.ts
+++ b/bigbluebutton-tests/playwright/reconnection/util.ts
@@ -26,3 +26,32 @@ export async function killConnection() {
     throw new Error(`Failed to kill connection to ${hostname}: ${error}`);
   }
 }
+
+// Sustained full outage toward the server: drop TCP:443 for `seconds` while
+// repeatedly killing established sockets, then restore. A brief (1 s) cut like
+// killConnection() lets the signaling websockets recover before the camera peers
+// tear down; the webcam-background reproduction needs those peers to be destroyed
+// and rebuilt, which requires an outage long enough to close their sockets. Like
+// killConnection(), this needs workstation sudo and severs ALL local connections
+// to the server, so specs using it must run standalone (--workers=1).
+export async function severConnection(seconds = 5) {
+  if (!hostname) {
+    throw new Error('hostname is undefined; ensure BBB_URL is set');
+  }
+  if (!/^[a-zA-Z0-9.-]+$/.test(hostname)) {
+    throw new Error(`Invalid hostname format: ${hostname}`);
+  }
+  if (!Number.isInteger(seconds) || seconds < 1 || seconds > 60) {
+    throw new Error(`severConnection: seconds must be an integer in 1..60, got ${seconds}`);
+  }
+
+  try {
+    await exec(`sudo iptables -A OUTPUT -p tcp -d ${hostname} --dport 443 -j DROP`);
+    for (let i = 0; i < seconds; i += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      await exec(`sudo ss -K dst ${hostname} dport https || true; sleep 1`);
+    }
+  } finally {
+    await exec(`sudo iptables -D OUTPUT -p tcp -d ${hostname} --dport 443 -j DROP`);
+  }
+}

--- a/bigbluebutton-tests/playwright/reconnection/webcamBackground.spec.ts
+++ b/bigbluebutton-tests/playwright/reconnection/webcamBackground.spec.ts
@@ -1,0 +1,43 @@
+// Reproduction spec for https://github.com/bigbluebutton/bigbluebutton/issues/25266
+// "[4.0] Webcam Background dropped after reconnection".
+//
+// Mechanism (one paragraph): the webcam virtual background is applied only in the
+// video-preview flow (useVideoPreview.ts applyStoredVirtualBg) and baked into the
+// cached BBBVideoStream. The video-provider republish path has no virtual-background
+// awareness. On a full connection loss, onWsClose() tears every camera peer down
+// (bbbVideoStream.stop() -> stopVirtualBackground + the preloaded-stream cache is
+// purged) and nulls the deviceId; when the connection returns, createPublisher()
+// calls VideoService.getPreloadedStream(), gets null, and wraps the RAW
+// peer.getLocalStream() with no re-application of the stored background - a silent
+// raw re-share. It is bbb-webrtc-sfu-bridge-specific: the LiveKit bridge has no raw
+// getUserMedia fallback (it fails loudly instead).
+//
+// This test asserts the DESIRED behavior (background still applied after
+// reconnection) and is wrapped in test.fail(): against current product code it
+// fails on every run (the suite stays green), and it flips to an unexpected pass
+// once the bug is fixed.
+//
+// Run notes:
+// - Reproduces on the bbb-webrtc-sfu camera bridge (4.0's default is LiveKit), so
+//   run it with MEDIA_BRIDGE=bbb-webrtc-sfu.
+// - Uses severConnection() (workstation sudo; severs ALL local connections to the
+//   server), so it must run standalone (--workers=1). It is deliberately NOT
+//   @ci-tagged, mirroring the rest of the reconnection suite (CI shards lack sudo).
+//   Do NOT move it into webcam/ (that describe block is @ci-tagged and sudo-free).
+
+import { checkRootPermission, linkIssue } from '../core/helpers';
+import { test } from '../core/setup/fixtures';
+import { WebcamBackground } from './webcamBackground';
+
+test.describe('Reconnection - webcam virtual background', () => {
+  test.fail(); // issue #25266: background is silently dropped on reconnection (bug present)
+
+  test('Virtual background survives a reconnection', async ({ browser, context, page }, testInfo) => {
+    linkIssue(25266);
+    await checkRootPermission(); // needs sudo to sever the connection
+    const webcamBackground = new WebcamBackground(browser, context);
+    await webcamBackground.initModPage(page, { testInfo });
+    await webcamBackground.initUserPage(context, { testInfo });
+    await webcamBackground.backgroundSurvivesReconnection();
+  });
+});

--- a/bigbluebutton-tests/playwright/reconnection/webcamBackground.ts
+++ b/bigbluebutton-tests/playwright/reconnection/webcamBackground.ts
@@ -1,0 +1,138 @@
+import { expect } from '@playwright/test';
+
+import { ELEMENT_WAIT_EXTRA_LONG_TIME } from '../core/constants';
+import { elements as e } from '../core/elements';
+import { Page } from '../core/page';
+import { MultiUsers } from '../user/multiusers';
+import { severConnection } from './util';
+
+// How the "is the virtual background still applied?" detector works.
+//
+// A virtual background is a canvas.captureStream() composite: the uploaded/preset
+// background image fills the frame corners and the (moving) camera feed sits in the
+// center. With the fake camera (a looping video.y4m), the four CORNER patches are
+// therefore static while VB is applied, and become a moving video the instant the
+// stream falls back to the raw camera. We sample each corner across several frames
+// and compute the temporal variance: ~0 == still shows the static background image;
+// a large value == raw feed. Calibrated on this suite's fake camera: VB corners
+// score < 1, raw corners score > 50 (both locally and on a viewer's received tile).
+// No pixel baselines are checked in - webcam.spec.ts already documents how flaky
+// cross-machine screenshot baselines are.
+const VB_CORNER_VARIANCE_MAX = 3;
+
+async function cornerVariance(page: Page['page'], selector: string, frames = 10): Promise<number | null> {
+  return page.evaluate(
+    async ({ selector, frames }) => {
+      const video = document.querySelector(selector) as HTMLVideoElement | null;
+      if (!video || !video.srcObject) return null;
+      const W = 200;
+      const H = 150;
+      const P = 24;
+      const canvas = document.createElement('canvas');
+      canvas.width = W;
+      canvas.height = H;
+      const ctx = canvas.getContext('2d');
+      if (!ctx) return null;
+      const corners = [
+        [4, 4],
+        [W - P - 4, 4],
+        [4, H - P - 4],
+        [W - P - 4, H - P - 4],
+      ];
+      const series: number[][] = [[], [], [], []];
+      for (let f = 0; f < frames; f += 1) {
+        try {
+          ctx.drawImage(video, 0, 0, W, H);
+        } catch {
+          return -1; // frame not drawable yet
+        }
+        corners.forEach(([x, y], i) => {
+          const { data } = ctx.getImageData(x, y, P, P);
+          let sum = 0;
+          for (let k = 0; k < data.length; k += 4) sum += data[k] + data[k + 1] + data[k + 2];
+          series[i].push(sum / (data.length / 4));
+        });
+        await new Promise((r) => {
+          setTimeout(r, 90);
+        });
+      }
+      const varianceOf = (arr: number[]) => {
+        const mean = arr.reduce((a, b) => a + b, 0) / arr.length;
+        return arr.reduce((a, b) => a + (b - mean) ** 2, 0) / arr.length;
+      };
+      return (varianceOf(series[0]) + varianceOf(series[1]) + varianceOf(series[2]) + varianceOf(series[3])) / 4;
+    },
+    { selector, frames },
+  );
+}
+
+export class WebcamBackground extends MultiUsers {
+  // Apply the default "Home" background through the preview and share the camera.
+  // Mirrors webcam/webcam.ts applyBackground() UI steps (without its screenshot
+  // assertion, which we deliberately do not use here).
+  async shareWithHomeBackground() {
+    await this.modPage.waitAndClick(e.joinVideo);
+    await this.modPage.waitAndClick(e.backgroundSettingsTitle);
+    await this.modPage.waitForSelector(e.noneBackgroundButton);
+    await this.modPage.waitAndClick(`${e.selectDefaultBackground}[aria-label="Home"]`);
+    await this.modPage.page.waitForTimeout(1000);
+    await this.modPage.waitAndClick(e.startSharingWebcam);
+    await this.modPage.waitForSelector(e.currentUserLocalStreamVideo, ELEMENT_WAIT_EXTRA_LONG_TIME);
+    await this.modPage.page.waitForTimeout(3000);
+    await this.userPage.waitForSelector(`${e.webcamVideoItem} video`, ELEMENT_WAIT_EXTRA_LONG_TIME);
+    await this.userPage.page.waitForTimeout(2000);
+  }
+
+  // Wait until the sharer's camera peer has been rebuilt after the outage and its
+  // self-view is flowing again (works whether it comes back with or without the
+  // background), then return the local + viewer corner variances.
+  private async waitForRepublishAndMeasure(): Promise<{ local: number; viewer: number }> {
+    let local = -1;
+    for (let i = 0; i < 20; i += 1) {
+      await this.modPage.page.waitForTimeout(2000);
+      const present = await this.modPage.page.locator(e.currentUserLocalStreamVideo).count();
+      if (present > 0) {
+        const cv = await cornerVariance(this.modPage.page, e.currentUserLocalStreamVideo);
+        // cv === -1 means the element exists but is not drawable yet (still frozen)
+        if (cv !== null && cv >= 0) {
+          local = cv;
+          if (cv > VB_CORNER_VARIANCE_MAX) break; // raw feed already visible
+        }
+      }
+    }
+    let viewer = -1;
+    for (let i = 0; i < 12; i += 1) {
+      const vv = await cornerVariance(this.userPage.page, `${e.webcamVideoItem} video`);
+      if (vv !== null && vv > viewer) viewer = vv;
+      if (viewer > VB_CORNER_VARIANCE_MAX) break;
+      await this.modPage.page.waitForTimeout(2000);
+    }
+    return { local, viewer };
+  }
+
+  async backgroundSurvivesReconnection() {
+    await this.shareWithHomeBackground();
+
+    // Pre-state: background is applied (corners static) on both perspectives.
+    const preLocal = await cornerVariance(this.modPage.page, e.currentUserLocalStreamVideo);
+    expect(preLocal, 'precondition: sharer self-view shows the background (static corners)').toBeLessThan(
+      VB_CORNER_VARIANCE_MAX,
+    );
+
+    // Trigger a full connection loss long enough to tear the camera peer down.
+    await severConnection(5);
+
+    const { local, viewer } = await this.waitForRepublishAndMeasure();
+
+    // After reconnection the background must STILL be applied. With the bug present
+    // the camera auto-republishes raw, so these assertions FAIL (test.fail() marks
+    // that as an expected failure); a fix flips this to an unexpected pass.
+    expect(local, 'sharer self-view background should survive reconnection (corners still static)').toBeLessThan(
+      VB_CORNER_VARIANCE_MAX,
+    );
+    expect(
+      viewer,
+      "viewer's received tile background should survive reconnection (published track kept the effect)",
+    ).toBeLessThan(VB_CORNER_VARIANCE_MAX);
+  }
+}


### PR DESCRIPTION
## Investigation: #25266 - webcam virtual background dropped after reconnection

This PR contains the **e2e spec and helpers** produced by the investigation of issue #25266. It does **not** include a fix - the bug is characterized and a fix direction is proposed in the investigation report.

### Bug summary

On the **`bbb-webrtc-sfu`** camera bridge, sharing a webcam with a virtual background and then losing all TCP:443 for ~5 seconds makes the camera **auto-republish as the raw feed with the background silently dropped**. The tile stays, no toast/error is shown, and the stored background choice is still saved.

Reproduced reliably **3/3** on `v4.0.x-develop` (`3cbd010f8b`, from source).

### Root cause

The virtual background is applied only in the video-preview flow (`applyStoredVirtualBg`) and baked into a cached `BBBVideoStream`. The video-provider republish path has **no virtual-background awareness**. On reconnection:

1. `onWsClose()` destroys camera peers -> `BBBVideoStream.stop()` -> `stopVirtualBackground()` resets to raw -> `deleteStream()` purges the preloaded-stream cache -> `deviceId` nulled.
2. `createPublisher()` calls `getPreloadedStream()` -> `null` -> `WebRtcPeer` does its own `getUserMedia` -> wraps the **raw** `peer.getLocalStream()` with no background re-application.

Confirmed live with log-only instrumentation (reverted): `stopVirtualBackground (was type=image)` -> `deleteStream purge` -> `getPreloadedStream -> null` -> `wrapping RAW, VB NOT re-applied`.

### Scope

- **SFU-bridge-specific.** The LiveKit camera bridge has no raw `getUserMedia` fallback (throws -> fails visibly, not silent).
- **Version note:** 3.0 defaults to `bbb-webrtc-sfu` (the affected bridge); 4.0 defaults to LiveKit (SFU is opt-in). This reconciles the 3.0-body / [4.0]-title ambiguity.
- Independent of background type (image/blur/custom) and `userSettingsStorage`.

### Suggested fix direction (not implemented)

Re-apply the stored background in the `createPublisher` fallback when `getPreloadedStream()` returns null (`getSessionVirtualBackgroundInfo(deviceId)` + `startVirtualBackground(...)`), or centralize `applyStoredVirtualBg` so every (re)publish path restores the background.

### What this PR includes

- `bigbluebutton-tests/playwright/reconnection/webcamBackground.spec.ts` - the spec, wrapped in `test.fail()`
- `bigbluebutton-tests/playwright/reconnection/webcamBackground.ts` - page object (sharer + viewer VB assertions, corner-variance detector)
- `bigbluebutton-tests/playwright/reconnection/util.ts` - `severConnection()` helper (sustained TCP cut; sudo-free `setOffline` fallback)

The spec runs standalone (`--workers=1`) and is deliberately **not** `@ci`-tagged (reconnection tests require conditions CI shards cannot provide).

Co-authored-by: Tainan Felipe <tainanfelipe214@gmail.com>