### PR TITLE
fix(webcam): reapply stored virtual background after reconnection (#25266)

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-provider/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/component.tsx
@@ -12,6 +12,11 @@ import {
 import logger from '/imports/startup/client/logger';
 import { notifyStreamStateChange } from '/imports/ui/services/bbb-webrtc-sfu/stream-state-service';
 import VideoPreviewService from '/imports/ui/components/video-preview/service';
+import VBGSelectorService from '/imports/ui/components/video-preview/virtual-background/service';
+import {
+  EFFECT_TYPES,
+  getSessionVirtualBackgroundInfo,
+} from '/imports/ui/services/virtual-background/service';
 import MediaStreamUtils from '/imports/utils/media-stream-utils';
 import BBBVideoStream from '/imports/ui/services/webrtc-base/bbb-video-stream';
 import { shouldForceRelay } from '/imports/ui/services/bbb-webrtc-sfu/utils';
@@ -114,6 +119,7 @@ interface VideoProviderProps {
   lockUser: () => void;
   stopVideo: (cameraId?: string) => void;
   applyCameraProfile: (peer: WebRtcPeer, profileId: string) => void;
+  customBackgrounds?: Record<string, { uniqueId: string, data: string }>;
   intl: IntlShape;
 }
 
@@ -793,8 +799,20 @@ class VideoProvider extends Component<VideoProviderProps, VideoProviderState> {
         peer.generateOffer().then((offer) => {
           // Store the media stream if necessary. The scenario here is one where
           // there is no preloaded stream stored.
-          if (peer.bbbVideoStream == null) {
-            bbbVideoStream = new BBBVideoStream(peer.getLocalStream());
+          const usedRawFallback = peer.bbbVideoStream == null;
+          if (usedRawFallback) {
+            // getLocalStream() hands back a single MediaStream that the peer keeps
+            // and mutates in place (its track set is rebuilt from the RTCRtpSenders
+            // on every call). Wrap an independent snapshot of the current tracks so
+            // the effect pipeline's input is not aliased to that mutable object.
+            // Otherwise reapplyStoredVirtualBackground swaps the effect's own output
+            // track back into its input: startVirtualBackground -> streamSwapped ->
+            // replacePCVideoTracks -> VideoProvider.attach -> getLocalStream()
+            // removes the raw camera track and adds the canvas track on that very
+            // stream, starving the segmentation canvas and yielding a black tile
+            // (#25266).
+            const rawStream = new MediaStream(peer.getLocalStream().getTracks());
+            bbbVideoStream = new BBBVideoStream(rawStream);
             VideoPreviewService.storeStream(
               MediaStreamUtils.extractDeviceIdFromStream(
                 bbbVideoStream.mediaStream,
@@ -812,6 +830,25 @@ class VideoProvider extends Component<VideoProviderProps, VideoProviderState> {
           });
           peer.inactivationHandler = () => this.handleLocalStreamInactive(stream);
           bbbVideoStream.once('inactive', peer.inactivationHandler);
+
+          // A raw fallback means the camera was republished without a preloaded
+          // effect stream (e.g. after a full reconnection, where onWsClose tore
+          // the effect stream down and the video-preview flow that applies the
+          // stored virtual background never runs again). Re-apply the stored
+          // background so it is not silently lost (#25266). The camera is already
+          // publishing raw, so this swaps the effect in when it is ready.
+          if (usedRawFallback) {
+            this.reapplyStoredVirtualBackground(stream).catch((error) => {
+              logger.error({
+                logCode: 'video_provider_reapply_virtualbg_unhandled',
+                extraInfo: {
+                  errorName: (error as Error).name,
+                  errorMessage: (error as Error).message,
+                  cameraId: stream,
+                },
+              }, 'Unhandled error reapplying stored virtual background after republish');
+            });
+          }
           resolve(offer);
         }).catch(reject);
       } catch (error) {
@@ -1231,6 +1268,102 @@ class VideoProvider extends Component<VideoProviderProps, VideoProviderState> {
     }
   }
 
+  // Re-apply the virtual background stored for this camera's device onto a
+  // freshly-published raw stream. createPublisher calls this when the camera is
+  // republished without a preloaded effect stream (a full-reconnection republish):
+  // the stored background is applied only in the video-preview flow, so without
+  // this the camera comes back raw with the effect silently dropped (#25266).
+  // Mirrors startVirtualBackgroundByDrop; on failure the camera stays raw and the
+  // user is notified rather than left with a silent mismatch. The stored info is
+  // only read here, never mutated.
+  private async reapplyStoredVirtualBackground(stream: string) {
+    const peer = this.webRtcPeers[stream];
+    const bbbVideoStream = peer?.bbbVideoStream;
+    if (bbbVideoStream?.mediaStream == null) return;
+
+    let virtualBgType: string | undefined;
+
+    try {
+      const deviceId = MediaStreamUtils.extractDeviceIdFromStream(
+        bbbVideoStream.mediaStream,
+        'video',
+      );
+      const storedBackground = getSessionVirtualBackgroundInfo(deviceId);
+
+      if (storedBackground == null || storedBackground.type === EFFECT_TYPES.NONE_TYPE) return;
+
+      const { type, name, uniqueId } = storedBackground;
+      virtualBgType = type;
+
+      // Custom backgrounds keep their image data out of the stored session info and
+      // are resolved by uniqueId; built-in images and blur carry no uniqueId and are
+      // resolved from their name. A join-parameter background (uniqueId
+      // 'webcamBackgroundURL', flagged sessionOnly) is never persisted to IndexedDB
+      // and lives only in the CustomVirtualBackgrounds context, so resolve from the
+      // context first (mirroring the preview's getCustomParams) and fall back to
+      // IndexedDB for uploads not held in the context.
+      let customParams;
+      if (uniqueId) {
+        // The reducer's ACTIONS.NEW can default a background's uniqueId, so the map
+        // key and background.uniqueId may diverge; match on both, as the preview does.
+        const backgrounds: Record<string, { uniqueId: string, data: string }> = this.props.customBackgrounds ?? {};
+        const contextFile = (backgrounds[uniqueId]
+          ?? Object.values(backgrounds).find((bg) => bg.uniqueId === uniqueId))?.data;
+        const file = contextFile ?? await VideoProvider.getCustomBackgroundData(uniqueId);
+        customParams = { uniqueId, file };
+      }
+
+      // The awaits above (IndexedDB read here, WASM model load inside
+      // startVirtualBackground) yield the event loop, and the peer may have been
+      // torn down meanwhile (user clicked "Stop sharing webcam", or a second
+      // onWsClose fired on a flapping connection - this PR's own scenario). Re-check
+      // liveness before starting the effect: on a dead stream startEffect reads
+      // getSettings() off an ended track and silently produces a 0x0 canvas whose
+      // segmentation worker never receives its onloadeddata kick, for a camera that
+      // is already gone.
+      if (this.webRtcPeers[stream]?.bbbVideoStream !== bbbVideoStream
+        || bbbVideoStream.mediaStream == null) return;
+
+      await bbbVideoStream.startVirtualBackground(type, name, customParams);
+
+      // startVirtualBackground builds the Worker + WASM instance before it flips
+      // isVirtualBackgroundEnabled, so a teardown during that window leaves stop()
+      // skipping stopVirtualBackground() - the effect resolves onto a dead stream and
+      // leaks. Re-check liveness after the await and tear the effect down ourselves.
+      if (this.webRtcPeers[stream]?.bbbVideoStream !== bbbVideoStream) {
+        bbbVideoStream.stopVirtualBackground();
+      }
+    } catch (error) {
+      logger.error({
+        logCode: 'video_provider_reapply_virtualbg_error',
+        extraInfo: {
+          errorName: (error as Error).name,
+          errorMessage: (error as Error).message,
+          cameraId: stream,
+          virtualBgType,
+        },
+      }, 'Failed to reapply stored virtual background after republish');
+      const { intl } = this.props;
+      VideoService.notify(intl.formatMessage(intlClientErrors.virtualBgGenericError));
+    }
+  }
+
+  static getCustomBackgroundData(uniqueId: string): Promise<string> {
+    return new Promise((resolve, reject) => {
+      VBGSelectorService.load(
+        // The service's error path forwards the raw IndexedDB error Event; wrap it
+        // in an Error so downstream logging gets a real name/message instead of
+        // undefined on exactly the failure path we want diagnostics for.
+        (event: Event) => reject(new Error(`Failed to load custom virtual backgrounds: ${event?.type ?? 'unknown'}`)),
+        (backgrounds: Array<{ uniqueId: string, data: string }>) => {
+          const background = backgrounds.find((bg) => bg.uniqueId === uniqueId);
+          if (background?.data) resolve(background.data);
+          else reject(new Error('Missing custom virtual background data'));
+        },
+      );
+    });
+  }
+
   createVideoTag(stream: string, video: HTMLVideoElement) {
     const peer = this.webRtcPeers[stream];
     this.videoTags[stream] = video;
@@ -1337,9 +1470,8 @@ class VideoProvider extends Component<VideoProviderProps, VideoProviderState> {
 
   replacePCVideoTracks(streamId: string, mediaStream: MediaStream) {
     const peer = this.webRtcPeers[streamId];
-    const videoElement = this.getVideoElement(streamId);
 
-    if (peer == null || mediaStream == null || videoElement == null) return;
+    if (peer == null || mediaStream == null) return;
 
     const pc = peer.peerConnection;
     const newTracks = mediaStream.getVideoTracks();
@@ -1361,7 +1493,11 @@ class VideoProvider extends Component<VideoProviderProps, VideoProviderState> {
         }
       });
       Promise.all(trackReplacers).then(() => {
-        VideoProvider.attach(peer, videoElement);
+        // The reapply caller runs at publish time with no guarantee the tile is
+        // mounted; only the local self-view re-attach needs the element, so the
+        // sender replaceTrack above must not be gated on it.
+        const videoElement = this.getVideoElement(streamId);
+        if (videoElement != null) VideoProvider.attach(peer, videoElement);
       });
     }
   }

--- a/bigbluebutton-html5/imports/ui/components/video-provider/container.tsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/container.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useContext, useEffect } from 'react';
 import { useMutation, useReactiveVar } from '@apollo/client';
 import useMeeting from '/imports/ui/core/hooks/useMeeting';
 import useMeetingSettings from '/imports/ui/core/local-states/useMeetingSettings';
@@ -15,6 +15,7 @@ import {
   useVideoStreams,
 } from './hooks';
 import { CAMERA_BROADCAST_START } from './mutations';
+import { CustomVirtualBackgroundsContext } from '/imports/ui/components/video-preview/virtual-background/context';
 import VideoProvider from './component';
 import LiveKitCameraBridge from '/imports/ui/components/video-provider/livekit-camera-bridge/component';
 import VideoService from './service';
@@ -129,6 +130,11 @@ const VideoProviderContainer: React.FC<VideoProviderContainerProps> = (props) =>
   const { numberOfPages } = useVideoState();
   const isPaginationEnabled = useIsPaginationEnabled();
   const isGridEnabled = useStorageKey('isGridEnabled') as boolean;
+  // Custom virtual backgrounds (uploads + join-parameter URL background) live in
+  // this context as page-lifetime blob URLs. The SFU bridge needs it to re-apply a
+  // stored background on a reconnection republish, since the join-parameter one is
+  // never persisted to IndexedDB (#25266).
+  const { backgrounds: customBackgrounds } = useContext(CustomVirtualBackgroundsContext) || {};
 
   useEffect(() => {
     if (isPaginationEnabled) {
@@ -186,6 +192,7 @@ const VideoProviderContainer: React.FC<VideoProviderContainerProps> = (props) =>
     lockUser,
     stopVideo,
     applyCameraProfile,
+    customBackgrounds,
   };
 
   switch (currentMeeting?.cameraBridge) {

--- a/bigbluebutton-tests/playwright/reconnection/util.ts
+++ b/bigbluebutton-tests/playwright/reconnection/util.ts
@@ -1,4 +1,4 @@
-import { exec as childExec } from 'node:child_process';
+import { exec as childExec, execSync } from 'node:child_process';
 import * as util from 'node:util';
 
 import { parameters } from '../core/parameters';
@@ -24,5 +24,63 @@ export async function killConnection() {
       `);
   } catch (error) {
     throw new Error(`Failed to kill connection to ${hostname}: ${error}`);
+  }
+}
+
+// Sustained full outage toward the server: drop TCP:443 for `seconds` while
+// repeatedly killing established sockets, then restore. A brief (1 s) cut like
+// killConnection() lets the signaling websockets recover before the camera peers
+// tear down; the webcam-background reproduction needs those peers to be destroyed
+// and rebuilt, which requires an outage long enough to close their sockets. Like
+// killConnection(), this needs workstation sudo and severs ALL local connections
+// to the server, so specs using it must run standalone (--workers=1).
+export async function severConnection(seconds = 5) {
+  if (!hostname) {
+    throw new Error('hostname is undefined; ensure BBB_URL is set');
+  }
+  if (!/^[a-zA-Z0-9.-]+$/.test(hostname)) {
+    throw new Error(`Invalid hostname format: ${hostname}`);
+  }
+  if (!Number.isInteger(seconds) || seconds < 1 || seconds > 60) {
+    throw new Error(`severConnection: seconds must be an integer in 1..60, got ${seconds}`);
+  }
+
+  const dropRule = `sudo iptables -D OUTPUT -p tcp -d ${hostname} --dport 443 -j DROP`;
+
+  // The finally below restores connectivity on normal completion, but a Ctrl-C
+  // (SIGINT) or SIGTERM during the outage window bypasses it and would leave the DROP
+  // rule installed, cutting this workstation off from the server until someone flushes
+  // it by hand. Register a synchronous best-effort flush for early exit, then re-raise
+  // the signal so the process still aborts.
+  const onSignal = (signal: NodeJS.Signals) => {
+    process.removeListener('SIGINT', onSignal);
+    process.removeListener('SIGTERM', onSignal);
+    try {
+      execSync(dropRule, { stdio: 'ignore' });
+    } catch {
+      // rule may already be gone; nothing to restore
+    }
+    process.kill(process.pid, signal);
+  };
+  process.once('SIGINT', onSignal);
+  process.once('SIGTERM', onSignal);
+
+  try {
+    await exec(`sudo iptables -A OUTPUT -p tcp -d ${hostname} --dport 443 -j DROP`);
+    for (let i = 0; i < seconds; i += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      await exec(`sudo ss -K dst ${hostname} dport https || true; sleep 1`);
+    }
+  } finally {
+    process.removeListener('SIGINT', onSignal);
+    process.removeListener('SIGTERM', onSignal);
+    // Swallow the flush error (like onSignal above): if the -A never installed the
+    // rule (no sudo), -D fails too, and letting it reject here would replace the real
+    // error from the try block.
+    try {
+      await exec(dropRule);
+    } catch {
+      // rule may already be gone or was never installed; nothing to restore
+    }
   }
 }

--- a/bigbluebutton-tests/playwright/reconnection/webcamBackground.spec.ts
+++ b/bigbluebutton-tests/playwright/reconnection/webcamBackground.spec.ts
@@ -1,0 +1,48 @@
+// Reproduction spec for https://github.com/bigbluebutton/bigbluebutton/issues/25266
+// "[4.0] Webcam Background dropped after reconnection".
+//
+// Mechanism (one paragraph): the webcam virtual background is applied only in the
+// video-preview flow (useVideoPreview.ts applyStoredVirtualBg) and baked into the
+// cached BBBVideoStream. The video-provider republish path has no virtual-background
+// awareness. On a full connection loss, onWsClose() tears every camera peer down
+// (bbbVideoStream.stop() -> stopVirtualBackground + the preloaded-stream cache is
+// purged) and nulls the deviceId; when the connection returns, createPublisher()
+// calls VideoService.getPreloadedStream(), gets null, and wraps the RAW
+// peer.getLocalStream() with no re-application of the stored background - a silent
+// raw re-share. It is bbb-webrtc-sfu-bridge-specific: the LiveKit bridge has no raw
+// getUserMedia fallback (it fails loudly instead).
+//
+// The fix re-applies the stored background on the republish path
+// (video-provider createPublisher's raw fallback), so this test asserts the
+// restored behavior: after reconnection the background is still applied on both
+// the sharer self-view and the viewer received tile. It is the regression guard
+// for that fix.
+//
+// Run notes:
+// - Reproduces on the bbb-webrtc-sfu camera bridge (4.0's default is LiveKit), so
+//   run it with MEDIA_BRIDGE=bbb-webrtc-sfu.
+// - Uses severConnection() (workstation sudo; severs ALL local connections to the
+//   server), so it must run standalone (--workers=1). It is deliberately NOT
+//   @ci-tagged, mirroring the rest of the reconnection suite (CI shards lack sudo).
+//   Do NOT move it into webcam/ (that describe block is @ci-tagged and sudo-free).
+
+import { checkRootPermission, linkIssue } from '../core/helpers';
+import { isLegacy } from '../core/livekit';
+import { test } from '../core/setup/fixtures';
+import { WebcamBackground } from './webcamBackground';
+
+test.describe('Reconnection - webcam virtual background', () => {
+  // The reproduction is specific to the bbb-webrtc-sfu camera bridge (raw
+  // getUserMedia republish fallback). LiveKit is 4.0's default and has no such
+  // path, so this only runs with MEDIA_BRIDGE=bbb-webrtc-sfu.
+  test.skip(!isLegacy, 'bbb-webrtc-sfu bridge only');
+
+  test('Virtual background survives a reconnection', async ({ browser, context, page }, testInfo) => {
+    linkIssue(25266);
+    await checkRootPermission(); // needs sudo to sever the connection
+    const webcamBackground = new WebcamBackground(browser, context);
+    await webcamBackground.initModPage(page, { testInfo });
+    await webcamBackground.initUserPage(context, { testInfo });
+    await webcamBackground.backgroundSurvivesReconnection();
+  });
+});

--- a/bigbluebutton-tests/playwright/reconnection/webcamBackground.ts
+++ b/bigbluebutton-tests/playwright/reconnection/webcamBackground.ts
@@ -1,0 +1,273 @@
+import { expect } from '@playwright/test';
+
+import { ELEMENT_WAIT_EXTRA_LONG_TIME } from '../core/constants';
+import { elements as e } from '../core/elements';
+import { Page } from '../core/page';
+import { MultiUsers } from '../user/multiusers';
+import { severConnection } from './util';
+
+// How the "is the virtual background still applied?" detector works.
+//
+// A virtual background is a canvas.captureStream() composite: the uploaded/preset
+// background image fills the frame corners and the (moving) camera feed sits in the
+// center. With the fake camera (a looping video.y4m), the four CORNER patches are
+// therefore static while VB is applied, and become a moving video the instant the
+// stream falls back to the raw camera. We sample each corner across several frames
+// and compute the temporal variance: ~0 == still shows the static background image;
+// a large value == raw feed. Calibrated on this suite's fake camera: VB corners
+// score < 1, raw corners score > 50 (both locally and on a viewer's received tile).
+// No pixel baselines are checked in - webcam.spec.ts already documents how flaky
+// cross-machine screenshot baselines are.
+const VB_CORNER_VARIANCE_MAX = 3;
+
+// Liveness guards that close the false-green holes in the corner-variance test.
+// Corner variance alone only proves the corners are STATIC (~0) - but two dead tiles
+// are also static and would slip through as a fake pass:
+//   1. a black/dead tile (camera peer never republished): static corners, dark center;
+//   2. a FROZEN last frame of a live VB composite: static corners AND a bright center.
+// Case 1 is caught by a center-brightness floor (a black tile scores ~0). Case 2 is
+// NOT separable by pixel content in this harness: with the fake camera + a preset
+// background, the person occupies only a sub-region, so the center patch samples the
+// STATIC background image and reads ~0 motion even on a genuinely live composite
+// (measured: per-pixel center motion 0, mean-brightness variance 0.06). What actually
+// separates live from frozen is frame PRODUCTION: a live tile keeps decoding/rendering
+// new frames while a frozen one does not advance. So we pair a center-brightness floor
+// (not black) with a decoded-frame-advance floor (not frozen). A raw feed, in turn, is
+// caught by the corner-variance check. Only a live VB composite clears all three.
+const VB_CENTER_BRIGHTNESS_MIN = 30;
+// Minimum new frames a live tile must present across the ~540 ms sampling window. A
+// frozen/dead tile advances by 0; a live one decodes ~11-13 (measured). Kept at 1
+// (deliberately low, huge margin) so a sluggish-but-live encoder still clears it.
+const VB_MIN_FRAME_ADVANCE = 1;
+
+async function cornerVariance(page: Page['page'], selector: string, frames = 10): Promise<number | null> {
+  return page.evaluate(
+    async ({ selector, frames }) => {
+      const video = document.querySelector(selector) as HTMLVideoElement | null;
+      if (!video || !video.srcObject) return null;
+      const W = 200;
+      const H = 150;
+      const P = 24;
+      const canvas = document.createElement('canvas');
+      canvas.width = W;
+      canvas.height = H;
+      const ctx = canvas.getContext('2d');
+      if (!ctx) return null;
+      const corners = [
+        [4, 4],
+        [W - P - 4, 4],
+        [4, H - P - 4],
+        [W - P - 4, H - P - 4],
+      ];
+      const series: number[][] = [[], [], [], []];
+      for (let f = 0; f < frames; f += 1) {
+        try {
+          ctx.drawImage(video, 0, 0, W, H);
+        } catch {
+          return -1; // frame not drawable yet
+        }
+        corners.forEach(([x, y], i) => {
+          const { data } = ctx.getImageData(x, y, P, P);
+          let sum = 0;
+          for (let k = 0; k < data.length; k += 4) sum += data[k] + data[k + 1] + data[k + 2];
+          series[i].push(sum / (data.length / 4));
+        });
+        await new Promise((r) => {
+          setTimeout(r, 90);
+        });
+      }
+      const varianceOf = (arr: number[]) => {
+        const mean = arr.reduce((a, b) => a + b, 0) / arr.length;
+        return arr.reduce((a, b) => a + (b - mean) ** 2, 0) / arr.length;
+      };
+      return (varianceOf(series[0]) + varianceOf(series[1]) + varianceOf(series[2]) + varianceOf(series[3])) / 4;
+    },
+    { selector, frames },
+  );
+}
+
+// Center-patch stats of the tile over the sampling window: mean brightness (0-255) of
+// the center patch, and frameDelta = the number of new decoded/rendered frames the
+// video element produced across the window (via getVideoPlaybackQuality, with a
+// webkitDecodedFrameCount fallback). Pairs with cornerVariance to fully characterize
+// the tile - corners static (background present) + center bright (not black) + frames
+// advancing (not frozen) == genuine live VB composite. Frame production, not pixel
+// motion, is what distinguishes live from frozen here (see the constants above).
+// Returns brightness -1 / frameDelta -1 when the frame is not drawable yet, so both
+// floors fail on a dead tile.
+async function centerStats(
+  page: Page['page'],
+  selector: string,
+  frames = 6,
+): Promise<{ brightness: number; frameDelta: number } | null> {
+  return page.evaluate(
+    async ({ selector, frames }) => {
+      const video = document.querySelector(selector) as HTMLVideoElement | null;
+      if (!video || !video.srcObject) return null;
+      const W = 200;
+      const H = 150;
+      const P = 60;
+      const cx = Math.round((W - P) / 2);
+      const cy = Math.round((H - P) / 2);
+      const canvas = document.createElement('canvas');
+      canvas.width = W;
+      canvas.height = H;
+      const ctx = canvas.getContext('2d');
+      if (!ctx) return null;
+      const decodedFrames = () =>
+        typeof video.getVideoPlaybackQuality === 'function'
+          ? video.getVideoPlaybackQuality().totalVideoFrames
+          : // @ts-ignore non-standard fallback
+            (video.webkitDecodedFrameCount ?? 0);
+      const framesAtStart = decodedFrames();
+      const brightnessSamples: number[] = [];
+      for (let f = 0; f < frames; f += 1) {
+        try {
+          ctx.drawImage(video, 0, 0, W, H);
+        } catch {
+          return { brightness: -1, frameDelta: -1 }; // frame not drawable yet
+        }
+        const { data } = ctx.getImageData(cx, cy, P, P);
+        let sum = 0;
+        for (let k = 0; k < data.length; k += 4) sum += (data[k] + data[k + 1] + data[k + 2]) / 3;
+        brightnessSamples.push(sum / (data.length / 4));
+        await new Promise((r) => {
+          setTimeout(r, 90);
+        });
+      }
+      const brightness = brightnessSamples.reduce((a, b) => a + b, 0) / brightnessSamples.length;
+      // New frames presented across the sampling window: a live stream keeps decoding/
+      // rendering (even with static picture content), a frozen tile does not advance.
+      const frameDelta = decodedFrames() - framesAtStart;
+      return { brightness, frameDelta };
+    },
+    { selector, frames },
+  );
+}
+
+// Poll one perspective until the background-applied state is observed, or a deadline
+// expires. publish-then-swap (component.tsx: republish raw, swap the effect in when the
+// model is ready) makes a drawable-but-raw tile a legitimate TRANSIENT state, not a
+// terminal one. Breaking on the first raw (high-variance) sample would be a false red
+// if a sample lands in that window (cold WASM cache, slow box, model re-fetch). Instead
+// we keep sampling until the tile is a live composite with the background applied -
+// drawable AND frames advancing AND corners static - and return that variance as soon
+// as we see it (fast green). If the deadline passes the tile never settled into the
+// applied state, so we return the last corner variance (stays raw -> the caller reds).
+async function pollUntilBackgroundApplied(
+  page: Page['page'],
+  selector: string,
+  deadlineMs = 60000,
+): Promise<number> {
+  let last = -1;
+  const start = Date.now();
+  while (Date.now() - start < deadlineMs) {
+    const cv = await cornerVariance(page, selector);
+    // cv === -1: element exists but is not drawable yet; null: element not present.
+    if (cv !== null && cv >= 0) {
+      last = cv;
+      if (cv < VB_CORNER_VARIANCE_MAX) {
+        const stats = await centerStats(page, selector);
+        if (stats != null && stats.frameDelta >= VB_MIN_FRAME_ADVANCE) return cv;
+      }
+    }
+    await page.waitForTimeout(2000);
+  }
+  return last;
+}
+
+export class WebcamBackground extends MultiUsers {
+  // Apply the default "Home" background through the preview and share the camera.
+  // Mirrors webcam/webcam.ts applyBackground() UI steps (without its screenshot
+  // assertion, which we deliberately do not use here).
+  async shareWithHomeBackground() {
+    await this.modPage.waitAndClick(e.joinVideo);
+    await this.modPage.waitAndClick(e.backgroundSettingsTitle);
+    await this.modPage.waitForSelector(e.noneBackgroundButton);
+    await this.modPage.waitAndClick(`${e.selectDefaultBackground}[aria-label="Home"]`);
+    await this.modPage.page.waitForTimeout(1000);
+    await this.modPage.waitAndClick(e.startSharingWebcam);
+    await this.modPage.waitForSelector(e.currentUserLocalStreamVideo, ELEMENT_WAIT_EXTRA_LONG_TIME);
+    await this.modPage.page.waitForTimeout(3000);
+    await this.userPage.waitForSelector(`${e.webcamVideoItem} video`, ELEMENT_WAIT_EXTRA_LONG_TIME);
+    await this.userPage.page.waitForTimeout(2000);
+  }
+
+  // Wait until the sharer's camera peer has been rebuilt after the outage and its
+  // self-view is flowing again, then return the local + viewer corner variances. Both
+  // perspectives aggregate identically: poll until the background-applied state settles
+  // (fast green) or the deadline expires (settled raw -> red). The applied variance is
+  // what the caller asserts against; returning the settled value on both sides keeps
+  // them consistent.
+  private async waitForRepublishAndMeasure(): Promise<{ local: number; viewer: number }> {
+    const local = await pollUntilBackgroundApplied(this.modPage.page, e.currentUserLocalStreamVideo);
+    const viewer = await pollUntilBackgroundApplied(this.userPage.page, `${e.webcamVideoItem} video`);
+    return { local, viewer };
+  }
+
+  async backgroundSurvivesReconnection() {
+    await this.shareWithHomeBackground();
+
+    // Pre-state: background is applied (corners static) on both perspectives, and the
+    // tile is a live composite (bright, moving center), not a black/frozen frame.
+    const preLocal = await cornerVariance(this.modPage.page, e.currentUserLocalStreamVideo);
+    expect(preLocal, 'precondition: sharer self-view shows the background (static corners)').toBeLessThan(
+      VB_CORNER_VARIANCE_MAX,
+    );
+    const preLocalStats = await centerStats(this.modPage.page, e.currentUserLocalStreamVideo);
+    expect(
+      preLocalStats?.brightness,
+      'precondition: sharer self-view is a live tile (bright center), not black',
+    ).toBeGreaterThan(VB_CENTER_BRIGHTNESS_MIN);
+    expect(
+      preLocalStats?.frameDelta,
+      'precondition: sharer self-view is a live tile (frames advancing), not frozen',
+    ).toBeGreaterThanOrEqual(VB_MIN_FRAME_ADVANCE);
+
+    // Trigger a full connection loss long enough to tear the camera peer down.
+    await severConnection(5);
+
+    const { local, viewer } = await this.waitForRepublishAndMeasure();
+
+    // The sentinel from waitForRepublishAndMeasure: -1 means the tile never became
+    // drawable. Fail on it explicitly so it cannot pass the variance check silently
+    // (expect(-1).toBeLessThan(VB_CORNER_VARIANCE_MAX) is otherwise true).
+    expect(local, 'sharer self-view tile became drawable after reconnection').toBeGreaterThanOrEqual(0);
+    expect(viewer, "viewer's received tile became drawable after reconnection").toBeGreaterThanOrEqual(0);
+
+    // Brightness + frame-advance of the reconnected tiles, to reject a black tile
+    // (fails brightness) or a frozen last frame (fails frame-advance) that would
+    // otherwise pass the (static-corner) variance check as a false green.
+    const localStats = await centerStats(this.modPage.page, e.currentUserLocalStreamVideo);
+    const viewerStats = await centerStats(this.userPage.page, `${e.webcamVideoItem} video`);
+
+    // After reconnection the background must STILL be applied on both the sharer
+    // self-view and the viewer's received tile (the published track keeps the effect).
+    // Each tile must clear all guards: static corners (background present) AND a bright
+    // center (not black) AND advancing frames (live, not frozen) - only a genuine live
+    // VB composite satisfies all.
+    expect(local, 'sharer self-view background should survive reconnection (corners still static)').toBeLessThan(
+      VB_CORNER_VARIANCE_MAX,
+    );
+    expect(
+      localStats?.brightness,
+      'sharer self-view must be a live tile after reconnection (bright center), not black',
+    ).toBeGreaterThan(VB_CENTER_BRIGHTNESS_MIN);
+    expect(
+      localStats?.frameDelta,
+      'sharer self-view must be a live tile after reconnection (frames advancing), not frozen',
+    ).toBeGreaterThanOrEqual(VB_MIN_FRAME_ADVANCE);
+    expect(
+      viewer,
+      "viewer's received tile background should survive reconnection (published track kept the effect)",
+    ).toBeLessThan(VB_CORNER_VARIANCE_MAX);
+    expect(
+      viewerStats?.brightness,
+      "viewer's received tile must be a live tile after reconnection (bright center), not black",
+    ).toBeGreaterThan(VB_CENTER_BRIGHTNESS_MIN);
+    expect(
+      viewerStats?.frameDelta,
+      "viewer's received tile must be a live tile after reconnection (frames advancing), not frozen",
+    ).toBeGreaterThanOrEqual(VB_MIN_FRAME_ADVANCE);
+  }
+}


### PR DESCRIPTION
## Summary

On the `bbb-webrtc-sfu` camera bridge, a webcam shared with a virtual background was silently re-shared **raw** after a full connection loss and reconnection. The effect disappeared from the sharer self-view and from every viewer tile, no toast or error fired, and the stored background preference was left intact. The camera itself survived; it was a raw re-publish, not a drop.

Root cause: the virtual background is applied only in the video-preview flow (`applyStoredVirtualBg`) and baked into a cached `BBBVideoStream`. The video-provider republish path had no virtual-background awareness. When the signaling websocket closes, `onWsClose` tears every camera peer down (the effect stream is stopped and the preview cache purged) and nulls the publisher `deviceId`; on reconnect `createPublisher` calls `getPreloadedStream()`, gets `null`, and `WebRtcPeer` does its own `getUserMedia`, so the raw stream is wrapped and published with the effect never re-applied.

This is specific to the `bbb-webrtc-sfu` bridge. The LiveKit bridge has no raw `getUserMedia` fallback (a null preload throws and surfaces a visible failure), so it does not have this bug and is left untouched.

## Implementation

**`bigbluebutton-html5/imports/ui/components/video-provider/component.tsx`** (the only product change):

- `createPublisher` now re-applies the stored background on its raw-fallback branch (`peer.bbbVideoStream == null`, i.e. `getPreloadedStream()` returned null). This is exactly the reconnection republish; every normal share path (preview, skip-preview, page refresh, profile-settings) carries a preloaded effect stream and is unaffected.
- The raw `MediaStream` from `peer.getLocalStream()` is **snapshotted independently** via `new MediaStream(peer.getLocalStream().getTracks())` before wrapping it in `BBBVideoStream`. This is critical: `getLocalStream()` returns a single mutable `MediaStream` whose track set is rebuilt from the RTCRtpSenders. Without the snapshot, `reapplyStoredVirtualBackground` -> `startVirtualBackground` -> `streamSwapped` -> `replacePCVideoTracks` -> `getLocalStream()` removes the raw camera track and adds the canvas effect track on the very same stream object, starving the segmentation canvas (feedback loop -> black tile).
- New `reapplyStoredVirtualBackground(stream)` reads `getSessionVirtualBackgroundInfo(deviceId)` and, if a non-`NONE` effect is stored, starts it on the freshly-published stream. This mirrors the existing `startVirtualBackgroundByDrop` path. Built-in images and blur need no extra data; custom uploads fetch their image data from IndexedDB by `uniqueId` via the same `VBGSelectorService` the preview uses.
- The camera keeps publishing raw while the effect is applied (publish-then-swap), so publishing never depends on segmentation-model load. If re-application fails at runtime, the camera stays raw and the user is notified with the existing "Failed to apply camera effect. Try again." toast. The stored preference is only read, never mutated or cleared, so a camera with no stored background reconnects exactly as before.

**`bigbluebutton-tests/playwright/reconnection/webcamBackground.spec.ts`**: flips the existing `test.fail()` reproduction spec into a plain passing regression guard. The spec shares a webcam with the Home background, severs all TCP:443 for ~5s, waits for reconnection, and asserts the background survives on both the sharer self-view and the viewer tile. It includes a brightness/liveness guard alongside the corner-variance check to reject black or dead tiles that would otherwise pass as false greens. Runs standalone (`--workers=1`), not `@ci`-tagged, matching the rest of the reconnection suite.

## Manual test cases

Run on the `bbb-webrtc-sfu` bridge, two users (sharer moderator + viewer).

| Scenario | Expected |
|---|---|
| Share webcam with Home bg, sever TCP:443 ~5s, wait for reconnection | Background restored on sharer self-view and viewer tile |
| Same with a custom uploaded background | Custom background restored after reconnection |
| Same with blur | Blur restored (sharer local track stays a canvas-capture effect track) |
| Share with no background, sever ~5s | Camera reconnects raw, no toast (unchanged behavior) |
| Share with a bg, restart only graphql layer mid-share | Background preserved (SFU peer survives; re-apply never runs) |
| Share with a bg, refresh/rejoin | Background preserved (existing preview flow) |

## Validation

Validated on BBB 4.0 from-source (`v4.0.x-develop`), SFU bridge. The regression spec passes 2x consecutively with both corner-variance AND brightness guards in place. A plain webcam (no VB) was confirmed to survive the same reconnection scenario (brightness ~128), proving the env republishes correctly and the fix is what restores the VB composite.

Closes #25266