### PR TITLE
fix(html5): reserve private chat preview space to prevent list reflow (#25416)

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/private-chat-list/chat-list-item/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/private-chat-list/chat-list-item/component.tsx
@@ -2,6 +2,7 @@
 /* eslint-disable jsx-a11y/no-access-key */
 import React, { useEffect } from 'react';
 import { defineMessages, useIntl } from 'react-intl';
+import Skeleton, { SkeletonTheme } from 'react-loading-skeleton';
 import { layoutSelect, layoutSelectInput, layoutDispatch } from '/imports/ui/components/layout/context';
 import { ACTIONS, PANELS } from '/imports/ui/components/layout/enums';
 import Styled from './styles';
@@ -36,6 +37,20 @@ interface PrivateChatListItemProps {
   index: number;
   privateChatSelectedCallback: () => void;
 }
+
+// Placeholder shown while the last-message preview is still being fetched, so the
+// item is born at its final height and the list does not reflow (see issue 25416).
+const PreviewSkeleton = () => {
+  const isRTL = layoutSelect((i: Layout) => i.isRTL);
+
+  return (
+    <SkeletonTheme baseColor="#DCE4EC">
+      <Styled.PreviewSkeleton>
+        <Skeleton direction={isRTL ? 'rtl' : 'ltr'} />
+      </Styled.PreviewSkeleton>
+    </SkeletonTheme>
+  );
+};
 
 const PrivateChatListItem = (props: PrivateChatListItemProps) => {
   const sidebarContent = layoutSelectInput((i: Input) => i.sidebarContent);
@@ -73,12 +88,15 @@ const PrivateChatListItem = (props: PrivateChatListItemProps) => {
     limit: 1,
   }; // to get only the last message from private chat
   const variables = { ...defaultVariables, requestedChatId: chat.chatId };
-  // Skip subscription if chat has no messages
-  const skipSubscription = totalMessages === 0;
+  // A non-empty chat will show a last-message preview, so its item must reserve the preview space
+  // from the first render (empty chats never have a preview and stay shorter). Empty chats also
+  // skip the per-item subscription entirely.
+  const hasAnyMessages = totalMessages > 0;
   const useChatMessageSubscription = useCreateUseSubscription<Message>(chatQuery, variables);
   const {
     data: chatMessageData,
-  } = useChatMessageSubscription((msg) => msg, skipSubscription) as GraphqlDataHookSubscriptionResponse<Message[]>;
+    loading: lastMessageLoading,
+  } = useChatMessageSubscription((msg) => msg, !hasAnyMessages) as GraphqlDataHookSubscriptionResponse<Message[]>;
 
   useEffect(() => {
     // Clear any previous timeout to prevent multiple executions
@@ -171,10 +189,15 @@ const PrivateChatListItem = (props: PrivateChatListItemProps) => {
               />
             </Styled.ChatHeading>
           )}
-          {(hasMessages || unreadMessagesToDisplay > 0) && (
+          {/* totalUnread is a subset of totalMessages (same chat row, chatSubscription.ts:22-23),
+              so unread > 0 implies hasAnyMessages; the unread badge below can never be orphaned. */}
+          {hasAnyMessages && (
             <Styled.ChatContent data-test="private-user-list-content">
               <Styled.MessageItemWrapper>
-                {lastMessage}
+                {/* On a subscription error the hook leaves loading true (known hook limitation,
+                    see PR notes), so the skeleton persists instead of resolving; the row still
+                    keeps its reserved height. */}
+                {lastMessageLoading ? <PreviewSkeleton /> : lastMessage}
               </Styled.MessageItemWrapper>
               {(unreadMessagesToDisplay > 0)
                 ? (

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/private-chat-list/chat-list-item/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/private-chat-list/chat-list-item/styles.ts
@@ -265,6 +265,11 @@ const ChatContent = styled.div`
 const MessageItemWrapper = styled.div`
   flex: 1;
   min-width: 0;
+  // Reserve one row height so a resolved-but-empty preview (a soft-deleted last message renders
+  // null in the still-shown wrapper) does not collapse the row below the others (issue 25416).
+  // box-sizing is border-box (global reset in client/main.html), so this is one text line plus
+  // the wrapper's own vertical padding.
+  min-height: calc(${fontSizeBase} * 2 + ${lgPadding} * 2);
   padding: ${lgPadding} ${xlPadding};
   overflow: hidden;
   white-space: nowrap;
@@ -273,6 +278,20 @@ const MessageItemWrapper = styled.div`
 
   [dir="rtl"] & {
     text-align: right;
+  }
+`;
+
+// Loading placeholder for the preview text, sized to one text line (line-height 2 x
+// fontSizeBase) so the skeleton -> text swap has no visual jump (issue 25416).
+const PreviewSkeleton = styled.div`
+  display: flex;
+  align-items: center;
+  width: 100%;
+  height: calc(${fontSizeBase} * 2);
+
+  & .react-loading-skeleton {
+    width: 70%;
+    height: 1rem;
   }
 `;
 
@@ -287,6 +306,7 @@ export default {
   ChatWrapper,
   ChatContent,
   MessageItemWrapper,
+  PreviewSkeleton,
   UnreadMessages,
   UnreadMessagesText,
   UserAvatar,

--- a/bigbluebutton-tests/playwright/chat/chat.spec.ts
+++ b/bigbluebutton-tests/playwright/chat/chat.spec.ts
@@ -18,6 +18,16 @@ test.describe.parallel('Chat', { tag: '@ci' }, () => {
     await chat.sendPrivateMessage();
   });
 
+  test('Private chat list item reserves preview space (no reflow)', async ({ browser, context, page }, testInfo) => {
+    const chat = new Chat(browser, context);
+    // Two attendees with distinct (non-substring) names: one gets a message (tall item), the
+    // other stays an empty chat (short item), so the per-item height assertion sees both.
+    await chat.initModPage(page, { testInfo });
+    await chat.initUserPage(context, { fullName: 'Bob', testInfo });
+    await chat.initUserPage2(context, { fullName: 'Carol', testInfo });
+    await chat.privateChatPreviewNoReflow();
+  });
+
   test('Clear chat', async ({ browser, context, page }, testInfo) => {
     const chat = new Chat(browser, context);
     await chat.initPages(page, testInfo);

--- a/bigbluebutton-tests/playwright/chat/chat.ts
+++ b/bigbluebutton-tests/playwright/chat/chat.ts
@@ -67,6 +67,101 @@ export class Chat extends MultiUsers {
     await this.userPage.waitAndClick(e.publicChatButton);
   }
 
+  // Opens the private chat with a specific user by name (the shared openPrivateChat helper only
+  // targets the last user in the list, which is not enough when seeding several chats).
+  async startPrivateChatWithUser(name: string) {
+    await this.modPage.waitAndClick(e.usersListSidebarButton);
+    const userItem = this.modPage.page.locator(e.userListItem, { hasText: name }).first();
+    await userItem.waitFor({ state: 'visible', timeout: ELEMENT_WAIT_LONGER_TIME });
+    await userItem.hover();
+    await userItem.locator(e.startPrivateChat).first().click();
+    await this.modPage.hasElement(e.hidePrivateChat, `should open the private chat with ${name}`);
+  }
+
+  // Regression guard for issue 25416: opening the private chat list used to render each item
+  // short (avatar + name only) and then grow it once the per-item last-message subscription
+  // resolved, making the list reflow. The item now reserves one text line for the preview
+  // (skeleton placeholder + a min-height backstop) so its height never changes while loading.
+  async privateChatPreviewNoReflow() {
+    // Seed two chats with legitimately different final heights: one with a last message (tall,
+    // reserves a preview line) and one left empty (short, no preview). The per-item assertion
+    // below must not conflate them - the whole point of the fix is that empty and non-empty
+    // rows differ.
+    await this.startPrivateChatWithUser(this.userPage.username);
+    // prevent a race condition when running on a deployed server
+    await this.modPage.page.waitForTimeout(500);
+    await this.modPage.fill(e.chatBox, e.message1);
+    await this.modPage.waitAndClick(e.sendButton);
+    await checkLastMessageSent(this.modPage, e.message1);
+    await this.startPrivateChatWithUser(this.userPage2.username); // empty chat, no message sent
+
+    // Let the chats-list subscription settle each chat's totalMessages before measuring. This is
+    // a different async source than the preview-lag bug under test: a just-created chat can mount
+    // with totalMessages still 0 (no preview reserved) and then resize to its real height once
+    // the count propagates, which would false-fail the stability check. Needed even with the
+    // ResizeObserver, which faithfully reports that unrelated resize.
+    await this.modPage.page.waitForTimeout(2000);
+
+    // Open the list and watch every item with a ResizeObserver installed BEFORE the click, so no
+    // sampling gap can hide a transient: the buggy build grows the non-empty item from its short
+    // to its tall height as the preview resolves, and the observer records both. A MutationObserver
+    // attaches the ResizeObserver to each item the moment it mounts. Heights are keyed by chat name
+    // (aria-label), not by node, so a React remount that split the short and tall heights across two
+    // nodes still lands both under the same key and fails the stability check.
+    await this.modPage.hasElement(e.privateChatButton, 'should display the private chat button');
+    const items: { name: string; heights: number[] }[] = await this.modPage.page.evaluate(
+      async ({ itemSel, buttonSel, durationMs }) => {
+        const heightsByName = new Map<string, Set<number>>();
+        const record = (el: Element) => {
+          const name = el.getAttribute('aria-label') ?? 'unknown';
+          const set = heightsByName.get(name) ?? new Set<number>();
+          set.add(Math.round(el.getBoundingClientRect().height));
+          heightsByName.set(name, set);
+        };
+        const observed = new WeakSet<Element>();
+        const resizeObserver = new ResizeObserver((entries) => entries.forEach((entry) => record(entry.target)));
+        const observe = (el: Element) => {
+          if (!observed.has(el)) {
+            observed.add(el);
+            record(el);
+            resizeObserver.observe(el);
+          }
+        };
+        const mutationObserver = new MutationObserver(() => document.querySelectorAll(itemSel).forEach(observe));
+        mutationObserver.observe(document.body, { childList: true, subtree: true });
+        (document.querySelector(buttonSel) as HTMLElement).click();
+        document.querySelectorAll(itemSel).forEach(observe);
+        await new Promise((resolve) => {
+          setTimeout(resolve, durationMs);
+        });
+        mutationObserver.disconnect();
+        resizeObserver.disconnect();
+        return Array.from(heightsByName.entries()).map(([name, set]) => ({ name, heights: Array.from(set) }));
+      },
+      { itemSel: e.privateChatItem, buttonSel: e.privateChatButton, durationMs: 2500 },
+    );
+
+    // both seeded chats must be present, and each individual item must have kept a single stable
+    // height (on the buggy build the non-empty item is observed at two heights, e.g. 48 then 94)
+    expect(items.length, 'should observe exactly the two seeded private chats').toBe(2);
+    items.forEach(({ name, heights }) => {
+      expect(
+        heights,
+        `the "${name}" private chat item height must be stable while the preview loads (observed: ${heights.join(', ')})`,
+      ).toHaveLength(1);
+    });
+
+    // The fix's actual behavior: the chat with a message reserves a preview line and is taller than
+    // the empty chat. This guards against a regression where willHavePreview is always false (no
+    // preview ever renders) - that would keep every item stable but at the short height, passing the
+    // checks above; here both rows would be equally short and this comparison would fail.
+    const stableHeights = items.map((item) => item.heights[0]).sort((a, b) => a - b);
+    expect(
+      stableHeights[stableHeights.length - 1],
+      'the chat with a message should be taller than the empty chat (preview line reserved)',
+    ).toBeGreaterThan(stableHeights[0]);
+  }
+
   async clearChat() {
     await openPublicChat(this.modPage);
 


### PR DESCRIPTION
## Summary

When the private chats list is opened, each item used to render at a short height (avatar + name only) and then grow taller once its last-message preview loaded, one item at a time. This made the whole list visibly reflow as each preview popped in.

**Expected:** items should keep a stable height from the first paint (reserving the preview space), so the list does not jump.

**Impact:** the private chat list now renders cleanly without any staggered height changes.

The fix reserves the preview space from the first render for chats that have messages, showing a `react-loading-skeleton` placeholder until the last message arrives. Empty chats keep their current behavior (no preview, shorter row). A `min-height` on the message wrapper backstops the height for the soft-deleted-last-message case.

## Root Cause

Each `PrivateChatListItem` opens its own `CHAT_MESSAGE_PRIVATE_SUBSCRIPTION` (limit 1) just to fetch the last message for the preview (`chat-list-item/component.tsx`). The preview block (`Styled.ChatContent`) was gated on `(hasMessages || unreadMessagesToDisplay > 0)`, where `hasMessages` is only true **after** that per-item subscription resolves. So the preview block was absent at mount and appeared later, making each item grow.

The chats-list subscription (`CHATS_SUBSCRIPTION`) already carries `totalMessages` per chat, so we know synchronously whether a chat will have a preview — but that value was not being used to reserve the space.

Introduced by commit `99966143e3` (2026-02-11), which gated `ChatContent` on `hasMessages` to hide the preview for empty chats. Before that, commit `ec3e0f1ab7` had removed the whole-item `return null` (needed so empty chats render for navigation), but the subsequent `hasMessages` gate reintroduced the height jump for non-empty chats.

## Implementation

**Approach: reserve preview space per item with a skeleton** (option 2 from the issue). Chosen over a whole-list loading state (would require lifting N per-item subscriptions into the parent and hold the list hostage to the slowest row) and over a schema change to expose the last message on the chat view (disproportionate backend/Hasura churn for a client render bug — good candidate for a separate follow-up).

### Files changed (4)

1. **`bigbluebutton-html5/.../private-chat-list/chat-list-item/component.tsx`**
   - Derive `hasAnyMessages = totalMessages > 0` (= `!skipSubscription`, from the chats-list data, known at first render). Use `!hasAnyMessages` to skip the per-item subscription for empty chats and `hasAnyMessages` to gate the preview block (replacing the old `(hasMessages || unreadMessagesToDisplay > 0)` — the `|| unread` clause was unreachable, since unread implies messages).
   - Destructure `loading` from the subscription hook and render `lastMessageLoading ? <PreviewSkeleton /> : lastMessage` inside `MessageItemWrapper`. Driving the skeleton off `loading` (rather than `!hasMessages`) prevents a stuck skeleton if the last message is deleted between the two subscriptions.
   - New `PreviewSkeleton` component using `react-loading-skeleton` (already a dependency) with `SkeletonTheme baseColor="#DCE4EC"` and RTL via `layoutSelect((i: Layout) => i.isRTL)` (the reactive pattern used by the parent chat component; no `@ts-ignore`, no settings-singleton import), matching the existing `SkeletonUserListItem` and `MenuSkeleton` patterns.

2. **`bigbluebutton-html5/.../private-chat-list/chat-list-item/styles.ts`**
   - `min-height: calc(${fontSizeBase} * 2 + ${lgPadding} * 2)` on `MessageItemWrapper` — a backstop that covers the edge case where the preview resolves to a null/absent message (a soft-deleted last message renders null in the still-shown wrapper, which would otherwise collapse below the other rows). The values derive from the existing tokens (`fontSizeBase`, `lgPadding`) so they track the text line height at every font-size setting. `box-sizing: border-box` is set globally in `client/main.html:31-37` (html + universal reset), so this calc is the content (one text line, line-height 2 × fontSizeBase = 2rem) plus the wrapper's own vertical padding (2 × lgPadding) — matching the natural text row exactly.
   - `PreviewSkeleton` styled div sized to one text line (`height: calc(${fontSizeBase} * 2)`) with the inner `.react-loading-skeleton` at `1rem` × `70%`, so the skeleton-to-text swap causes zero height delta.

3. **`bigbluebutton-tests/playwright/chat/chat.ts`** + **`chat.spec.ts`**
   - E2e test `privateChatPreviewNoReflow`: seeds **two chats with legitimately different final heights** (one with a message → tall, one empty → short) via a new `startPrivateChatWithUser` helper. Opens the private chat list and observes each item with a **ResizeObserver** (attached via a MutationObserver the moment each item mounts, before the click) over a 2500ms window. Heights are keyed by **chat name (`aria-label`)** rather than by DOM node, so a React remount that splits short/tall across two nodes still lands both under one key and fails the stability check. Asserts: exactly 2 items observed, each with a single stable height, and the non-empty item is taller than the empty one (guards a regression where the preview never renders).

### What is NOT changed
- Empty chats (`totalMessages === 0`): `hasAnyMessages` is false, so no `ChatContent` renders — byte-identical final state to before.
- Unread badge (including the 2s delay when the chat is open), keyboard roving/focus, `CSSTransition`/`TransitionGroup`, `privateChatSelectedCallback`, RTL: all untouched.

## Test Coverage

### `Private chat list item reserves preview space (no reflow)`
**Objective:** verify each private chat list item's height does not change while the preview loads.

**Scenario:** a moderator starts two private chats — one with a message sent (tall item that reserves a preview line), one left empty (short item, no preview) — then opens the private chat list.

**Assertions:**
- Exactly 2 chats are observed.
- Each individual item's `getBoundingClientRect().height`, sampled via a ResizeObserver from mount through a 2500ms window, yields a single distinct value (per-item height stability).
- The non-empty chat's stable height is greater than the empty chat's (guards a "no preview ever renders" regression).

**Result:** Fails on the original code (the non-empty item is observed at two heights, 48 then 94), passes on the fixed code. Red-to-green confirmed against the live from-source environment.

## Manual Test Cases

| Scenario | Expected | Result |
|---|---|---|
| Open private chat list with 3 chats that have messages | All items appear at stable height immediately, skeleton briefly visible then text swaps in with no reflow | Pass |
| Open private chat list with an empty chat (no messages) | Empty chat row is shorter (no preview), non-empty rows are taller — same as before the fix | Pass |
| Open private chat list mixing empty and non-empty chats | Each item keeps its own stable height; empty stays short, non-empty stays tall, no item grows after mount | Pass |
| Unread badge on a chat with unread messages | Badge appears with the normal 2s delay when the chat is open | Pass |
| Keyboard navigation (up/down arrows) through the list | Roving focus works, each item is focusable | Pass |
| RTL layout | Skeleton direction follows RTL setting | Pass |

## Evidence

**Before fix** - the list items render short then grow as previews load (staggered reflow):

[![Before fix](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-07-14/94e8b755-7185-456e-b449-83d3cddf350f/before.gif)](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-07-14/70d32609-d518-4df5-970c-ffbd44a6a3e1/repro_before.mp4)

**After fix** - items are born at stable height, skeleton reserves the preview space, no reflow:

[![After fix](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-07-14/00550c64-fb2e-4456-bb52-a93b020122ff/after.gif)](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-07-14/2f8967af-317c-4915-994d-c4d7c7d542cd/repro_after.mp4)

DOM height probe (deterministic): before, non-empty items born at 48px jumping to 94px staggered (82ms to 446ms); after, items born at their final height and stay there.

E2e test logs: fails on original (the non-empty item observed at heights 48, 94), passes on fixed (each item stable).

## Risks / Notes

- **Subscription error path (known limitation):** if the per-item preview subscription errors, the subscription hook (`createUseSubscription`) leaves `loading` true indefinitely (its error handler only `console.error`s and never flips `loading`), so the skeleton keeps shimmering. Pre-PR this was invisible (the block simply did not render on error). This is a real but low-frequency behavioral change. The proper fix belongs in the subscription hook (the error path should set `loading: false`), which is out of scope for a UI layout fix and should be a separate PR. The row's `min-height` still holds its height in this case; only the shimmer does not stop. No workaround is added here because a timeout would mask the real hook bug.
- **Deleted-last-message edge:** a non-empty chat whose last message is soft-deleted (`ChatMessageDAO.softDelete` sets `message = NULL` and keeps the row; the `totalMessages` trigger only decrements on hard DELETE) resolves with `hasMessages` true but a null message — rendering an empty reserved preview box. The `min-height` backstop holds the row height. Showing the localized "Message deleted" text (matching what the message list does for deleted messages) would be the polished answer, but is out of scope.
- **Timestamp pop-in (horizontal, not vertical):** the last-message time rides the same per-item subscription and renders late in `PrivateChatListHeader`, which re-ellipsises the name horizontally. Same root cause; does not cause vertical reflow (the name drives the header height); out of scope here.
- **Alternative considered (schema):** exposing the last message on the `Chat` view via a `LATERAL` join on `chat_message` would eliminate the per-item subscriptions entirely and make the preview available from the first paint without a skeleton. This is architecturally cleaner (removes the N+1 of N chats opening N subscriptions) but touches the DB view, Hasura metadata, and the client subscription — disproportionate blast radius for a client render bug. Good candidate for a separate follow-up.

Closes #25416