### PR TITLE
fix(web): Cache-Control for immutable presentation slide SVGs

### DIFF
--- a/bigbluebutton-web/nginx-confs/presentation-slides.nginx
+++ b/bigbluebutton-web/nginx-confs/presentation-slides.nginx
@@ -31,6 +31,28 @@
                 alias    /var/bigbluebutton/$meeting_id_2/$meeting_id_2/$pres_id/svgs/slide$page_num.svg;
                 add_header 'Access-Control-Allow-Origin' $bbb_cors_origin always;
                 add_header 'Access-Control-Allow-Credentials' 'true' always;
+                # A converted slide SVG is immutable for its (meeting, presentation, page)
+                # URL, so let the browser cache it and skip revalidation. Without this the
+                # response carries only ETag/Last-Modified (heuristic freshness ~0 on a
+                # just-converted file), so every consumer of the same URL - the decode-gate
+                # Image prime, tldraw's background-image, the forward prefetch - triggers a
+                # full transfer plus an auth_request subrequest instead of a cache hit.
+                # private: the asset is auth-gated, never shared-cacheable.
+                #
+                # No `always`: this header must stay off non-2xx responses. A slide can 404
+                # while BBB is still converting pages, and checkAuthorization can 401/403 on
+                # a token race; caching those for a day (404 is heuristically cacheable, and
+                # an explicit max-age makes an otherwise-uncacheable status storable per
+                # RFC 9111) would pin a transient failure in the browser for the rest of the
+                # meeting. The neighbouring CORS `always` modifiers are required (the browser
+                # must read CORS headers on error responses); this one is not.
+                #
+                # max-age is deliberately short. The URL is stable for the whole meeting
+                # (Auth.authenticateURL is idempotent), so a long-lived immutable entry would
+                # let a browser re-render slides with no auth_request long after the user was
+                # ejected or the meeting ended. A short lifetime keeps revocation meaningful
+                # while still serving the repeat loads of a single slide navigation from cache.
+                add_header 'Cache-Control' 'private, max-age=600, immutable';
         }
 
         location ~^\/bigbluebutton\/presentation\/(?<meeting_id_1>[A-Za-z0-9\-]+)\/(?<meeting_id_2>[A-Za-z0-9\-]+)\/(?<pres_id>[A-Za-z0-9\-]+)\/pdf\/(?<job_id>[A-Za-z0-9]+)\/annotated_slides.pdf$ {


### PR DESCRIPTION
## What this does

Presentation slide SVGs are immutable for their `(meeting, presentation, page)` URL, but `presentation-slides.nginx` serves them with only `ETag`/`Last-Modified`, so a just-converted file has heuristic freshness near zero. Every consumer of the same URL then pays a full transfer plus an `auth_request` subrequest instead of a cache hit:

- tldraw's `background-image` load for the slide,
- the forward prefetch,
- and the slide decode-gate's `Image` prime added in the sibling PR (https://github.com/Tainan404/bigbluebutton/pull/69, the white-flash fix for issue 25397). The decode-gate warms the browser cache so the visible swap is a cache hit; without a `Cache-Control` on the SVG that priming is largely wasted.

This adds `Cache-Control: private, max-age=600, immutable` to the slide SVG location.

## Why `max-age=600` and not a day

The slide URL is stable for the whole meeting (`Auth.authenticateURL` is idempotent), which is exactly what makes caching work and also what makes a long-lived `immutable` entry reusable with no `auth_request` at all. That would let a browser profile keep re-rendering slides after the user was ejected or the meeting ended, weakening the `SessionToken` + `PageToken` enforcement added in issue 25020.

The gate only needs the cache entry to survive a slide navigation (seconds), not a day. A short `max-age` keeps the cache-hit benefit for navigation while keeping revocation meaningful.

## Why no `always`

`add_header` without `always` applies only to 2xx/3xx responses, which is what we want here. A slide can `404` while BBB is still converting pages, and `checkAuthorization` can `401`/`403` on a token race. An explicit `max-age` makes an otherwise-uncacheable status storable (RFC 9111 section 3), and `404` is already heuristically cacheable, so with `always` a single transient failure would be pinned in the browser cache for the rest of the meeting (a permanently broken slide that a reload cannot fix, and a cached error makes `Image.decode()` reject instantly, silently disabling the decode-gate for that slide). The two neighbouring CORS `always` modifiers stay, because the browser must read CORS headers on error responses.

## Why a separate PR

Split out of the white-flash fix (https://github.com/Tainan404/bigbluebutton/pull/69) so the authorization-model tradeoff on the cache lifetime gets its own maintainer/security review instead of riding along in a UI fix, and so the client-side fix can land independently of this decision.

## Validation

Verified on a from-source 3.0 server with this change deployed:

- `nginx -t` passes with the fragment included in a server block.
- A `200` slide SVG carries `Cache-Control: private, max-age=600, immutable` (captured from the live browser session that renders the slide).
- An error response on that same location (a `401` from `checkAuthorization`) carries no `Cache-Control` header.

The not-yet-converted `404` case rests on nginx's documented `add_header` scoping: without `always` the header is emitted only for 2xx/3xx, so a transient `404`/`401`/`403` never receives it (the reason for dropping `always`). I did not synthesize that conversion race live.
