### PR TITLE
fix: broadcast external video seek detected via onProgress discontinuity (#25472)

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/MakePresentationDownloadReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/MakePresentationDownloadReqMsgHdlr.scala
@@ -12,7 +12,6 @@ import org.bigbluebutton.core.running.LiveMeeting
 import org.bigbluebutton.core.util.RandomStringGenerator
 
 import java.io.File
-import java.net.URI
 
 trait MakePresentationDownloadReqMsgHdlr extends RightsManagementTrait {
   this: PresentationPodHdlrs =>
@@ -173,16 +172,18 @@ trait MakePresentationDownloadReqMsgHdlr extends RightsManagementTrait {
         bus.outGW.send(buildStoreAnnotationsInRedisSysMsg(annotations, liveMeeting))
       } else {
         // Return existing uploaded file directly
-        val convertedFileName = new URI(null, null, currentPres.get.filenameConverted, null).getRawPath
-        val originalFilename = new URI(null, null, currentPres.get.name, null).getRawPath
+        val convertedFileName = currentPres.get.filenameConverted
+        val originalFilename = currentPres.get.name
         val originalFileExt = originalFilename.split("\\.").last
         val convertedFileExt = if (convertedFileName != "") convertedFileName.split("\\.").last else ""
 
-        val convertedFileURI = if (convertedFileName != "") List("presentation", "download", meetingId,
-          s"${presId}?presFilename=${presId}.${convertedFileExt}&filename=$convertedFileName").mkString("", File.separator, "")
+        val convertedFileURI = if (convertedFileName != "") PresentationDownloadUrlBuilder.buildFileUri(
+          meetingId, presId, convertedFileExt, convertedFileName
+        )
         else ""
-        val originalFileURI = List("presentation", "download", meetingId,
-          s"${presId}?presFilename=${presId}.${originalFileExt}&filename=$originalFilename").mkString("", File.separator, "")
+        val originalFileURI = PresentationDownloadUrlBuilder.buildFileUri(
+          meetingId, presId, originalFileExt, originalFilename
+        )
 
         val event = buildNewPresFileAvailable("", originalFileURI, convertedFileURI, presId,
           m.body.fileStateType)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/PresentationConversionCompletedSysPubMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/PresentationConversionCompletedSysPubMsgHdlr.scala
@@ -8,8 +8,6 @@ import org.bigbluebutton.core.models.PresentationInPod
 import org.bigbluebutton.core.running.LiveMeeting
 import org.bigbluebutton.core2.message.senders.MsgBuilder
 
-import java.io.File
-import java.net.URI
 import java.time.{Instant, Duration}
 
 trait PresentationConversionCompletedSysPubMsgHdlr {
@@ -61,9 +59,9 @@ trait PresentationConversionCompletedSysPubMsgHdlr {
 
       PresPresentationDAO.updatePages(presWithConvertedName)
       if (pres.downloadable) {
-        val originalFilename = new URI(null, null, pres.name, null).getRawPath
-        val originalFileURI = List("presentation", "download", meetingId,
-          s"${pres.id}?presFilename=${pres.id}.${originalDownloadableExtension}&filename=$originalFilename").mkString("", File.separator, "")
+        val originalFileURI = PresentationDownloadUrlBuilder.buildFileUri(
+          meetingId, pres.id, originalDownloadableExtension, pres.name
+        )
         PresPresentationDAO.updateDownloadUri(pres.id, originalFileURI)
       }
       if(pres.current) {

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/PresentationDownloadUrlBuilder.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/PresentationDownloadUrlBuilder.scala
@@ -1,0 +1,23 @@
+package org.bigbluebutton.core.apps.presentationpod
+
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
+
+object PresentationDownloadUrlBuilder {
+  private def encodeQueryValue(value: String): String = {
+    URLEncoder.encode(value, StandardCharsets.UTF_8).replace("+", "%20")
+  }
+
+  def buildFileUri(
+      meetingId:        String,
+      presentationId:   String,
+      fileExtension:    String,
+      downloadFilename: String
+  ): String = {
+    val storedFilename = encodeQueryValue(s"${presentationId}.${fileExtension}")
+    val encodedDownloadFilename = encodeQueryValue(downloadFilename)
+
+    s"presentation/download/${meetingId}/${presentationId}" +
+      s"?presFilename=${storedFilename}&filename=${encodedDownloadFilename}"
+  }
+}

--- a/bbb-recording-imex/pom.xml
+++ b/bbb-recording-imex/pom.xml
@@ -75,7 +75,7 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-core</artifactId>
-            <version>1.5.33</version>
+            <version>1.5.34</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/bbb-shared-notes-server/package-lock.json
+++ b/bbb-shared-notes-server/package-lock.json
@@ -2311,9 +2311,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
@@ -47,6 +47,32 @@ import getStorageSingletonInstance from '/imports/ui/services/storage';
 
 const AUTO_PLAY_BLOCK_DETECTION_TIMEOUT_SECONDS = 5;
 const TWITCH_VIDEO_SEEK_TIME_WINDOW = 1; // Twitch video seek time in seconds
+// react-player reports onProgress on this interval (its default; BBB does not override it).
+// It is passed to the player explicitly (progressInterval below) so a future prop change
+// cannot silently halve the detector's sensitivity.
+const PROGRESS_INTERVAL_SECONDS = 1;
+// Minimum divergence (seconds) between the expected playback position and the reported one
+// for a tick to be treated as a seek that react-player did not surface via onSeek (which is
+// every provider except FilePlayer, e.g. a YouTube scrub). A normal tick advances by about
+// playerPlaybackRate seconds, so a jump larger than a couple of intervals is a seek.
+// Sub-threshold scrubs (up to ~2s) are NOT broadcast, and nothing re-syncs the viewer
+// position periodically (viewers only re-seek when updatedAt changes), so a missed scrub
+// leaves viewers permanently offset by that amount and repeated small scrubs accumulate.
+// The threshold is a deliberate trade: tiny drags do not yank viewers, at the cost of a
+// standing offset that is only corrected by the next above-threshold seek.
+const SEEK_DETECTION_THRESHOLD_SECONDS = 2 * PROGRESS_INTERVAL_SECONDS;
+// After detecting a discontinuity, stash it and confirm on the next tick that the new
+// position is a sustained playback point before broadcasting. A single-tick glitch (a
+// YouTube ad boundary, where getCurrentTime returns the ad position near 0, or a buffering
+// hiccup) reports a transient position that self-corrects, so demanding two consistent ticks
+// filters it at the cost of ~1s of viewer-follow latency (viewers already lag by about that).
+// This path is the only seek propagation for every provider except FilePlayer, so the
+// insurance is worth it.
+const SEEK_CONFIRMATION_THRESHOLD_SECONDS = SEEK_DETECTION_THRESHOLD_SECONDS;
+// Minimum wall-clock gap between two broadcast seeks from the discontinuity detector. Cheap
+// insurance against a provider whose getCurrentTime oscillates and would otherwise fan out a
+// mutation (a DB write plus a recording event) to every participant every tick.
+const MIN_SEEK_BROADCAST_INTERVAL_SECONDS = 2;
 
 const intlMessages = defineMessages({
   autoPlayWarning: {
@@ -199,10 +225,33 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
   const timeoutRef = useRef<ReturnType<typeof setTimeout>>();
   const presenterRef = useRef(isPresenter);
   const [reactPlayerPlaying, setReactPlayerPlaying] = React.useState(false);
+  // Mirrors reactPlayerPlaying for synchronous reads inside callbacks (avoids a stale
+  // closure): handleOnPlay must know whether this was a real resume or a YouTube re-play
+  // after buffering on a seek.
+  const reactPlayerPlayingRef = useRef(false);
   const firstPlayRef = useRef(true);
   const [playerUrl, setPlayerUrl] = React.useState('');
   const lastCursorRef = useRef<{ position: number, updateAt: number }>({ position: 0, updateAt: 0 });
+  // Tracks the last onProgress tick (playedSeconds + wall-clock) so handleProgress
+  // can detect a seek the player did not surface via onSeek (every provider except
+  // FilePlayer, e.g. a YouTube scrub).
+  const lastProgressRef = useRef<{ playedSeconds: number, at: number } | null>(null);
+  // A detected discontinuity awaiting the two-tick confirmation (see
+  // SEEK_CONFIRMATION_THRESHOLD_SECONDS). Reset wherever the baseline is reset.
+  const pendingSeekRef = useRef<{ playedSeconds: number, at: number } | null>(null);
+  // Wall-clock of the last seek broadcast by the discontinuity detector, for the rate limit.
+  const lastSeekBroadcastAtRef = useRef(0);
+  // Monotonic tick counter: getPlaybackRate can be async (Vimeo), so two handleProgress
+  // invocations can be in flight; a stale tick must not emit or seed the baseline.
+  const tickSeqRef = useRef(0);
   const [stopExternalVideoShare] = useMutation(EXTERNAL_VIDEO_STOP);
+
+  // Keep the synchronous mirror ref and the state in sync so the ref never drifts from
+  // reactPlayerPlaying (the ref is read inside async callbacks to dodge a stale closure).
+  const setPlayerPlaying = (value: boolean) => {
+    reactPlayerPlayingRef.current = value;
+    setReactPlayerPlaying(value);
+  };
 
   let currentTime = getServerCurrentTime();
 
@@ -338,6 +387,13 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
     } else {
       setPlayerUrl(videoUrl);
     }
+    // New video (or a player remount via playerKey rides the same reset path): clear the
+    // progress baseline so a stale position from the previous video is not misread as a seek
+    // on the first tick, drop any pending discontinuity, and reset the playing mirror so it
+    // does not carry a stale "was playing" into the fresh player.
+    lastProgressRef.current = null;
+    pendingSeekRef.current = null;
+    reactPlayerPlayingRef.current = false;
   }, [videoUrl, isPresenter]);
 
   useEffect(() => {
@@ -418,6 +474,13 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
         setVolume(playerVolume > 1 ? playerVolume / 100 : playerVolume);
       }
 
+      // Reset the progress baseline on any presenter change. A stalled or autoplay-blocked
+      // viewer promoted to presenter would otherwise broadcast a spurious seek from its
+      // stale position on the first tick, yanking the whole meeting. A null baseline is the
+      // safe state (the next tick re-seeds).
+      lastProgressRef.current = null;
+      pendingSeekRef.current = null;
+
       presenterRef.current = isPresenter;
     }
   }, [isPresenter]);
@@ -440,10 +503,17 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
     if (currentTime > playerCurrentTime) {
       playerRef?.current?.seekTo(currentTime, 'seconds');
     }
+    // Reset the progress baseline; the first onProgress tick after start seeds it. A start is
+    // also the remount path (new player mounts), so reset the pending discontinuity and the
+    // playing mirror too.
+    lastProgressRef.current = null;
+    pendingSeekRef.current = null;
+    reactPlayerPlayingRef.current = false;
   };
 
   const handleOnPlay = async () => {
-    setReactPlayerPlaying(true);
+    const wasPlaying = reactPlayerPlayingRef.current;
+    setPlayerPlaying(true);
     const internalPlayer = playerRef.current?.getInternalPlayer();
     const url = new URL(videoUrl);
     const isTwitch = url.hostname === 'twitch.tv' || url.hostname === 'www.twitch.tv';
@@ -475,10 +545,17 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
     if (firstPlayRef.current) {
       firstPlayRef.current = false;
     }
+    // Reset the baseline only on a genuine paused->playing transition. react-player also
+    // fires onPlay when YouTube re-enters PLAYING after buffering on a far seek; nulling
+    // the baseline there would swallow the very discontinuity we need to detect (#25472).
+    if (!wasPlaying) {
+      lastProgressRef.current = null;
+      pendingSeekRef.current = null;
+    }
   };
 
   const handleOnStop = async () => {
-    setReactPlayerPlaying(false);
+    setPlayerPlaying(false);
     if (isPresenter && playing) {
       const internalPlayer = playerRef.current?.getInternalPlayer();
       let rate = (internalPlayer instanceof HTMLVideoElement || internalPlayer instanceof HTMLAudioElement)
@@ -499,21 +576,103 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
     if (!isPresenter && playing) {
       playVideo(playerRef.current as ReactPlayer);
     }
+    // A pause resets the baseline so the following progress tick seeds fresh
+    // instead of accumulating drift against the pre-pause position.
+    lastProgressRef.current = null;
+    pendingSeekRef.current = null;
   };
 
   const handleProgress = async (state: OnProgressProps) => {
     setPlayed(state.played);
     setLoaded(state.loaded);
+    // Snapshot the baseline and wall-clock before the await below. getPlaybackRate can be
+    // async (Vimeo), so an interleaved handleOnSeek could otherwise land between the read
+    // and the write; capturing here keeps this tick consistent and lets the write below be
+    // skipped when a fresher baseline was synced meanwhile.
+    const now = Date.now();
+    const baseline = lastProgressRef.current;
+    // Claim a monotonic sequence for this tick. If a newer tick starts while we await the
+    // (possibly async) rate read below, the newer one owns the cycle and this stale tick must
+    // not emit a seek or seed the baseline. This closes the tick-vs-tick race, distinct from
+    // the interleaved handleOnSeek case the identity guard on the baseline write covers.
+    tickSeqRef.current += 1;
+    const seq = tickSeqRef.current;
     if (playing && isPresenter) {
       currentTime = getServerCurrentTime();
     }
     const interPlayerPlaybackRate = await getPlaybackRate(playerRef.current as ReactPlayer);
-    if (isPresenter && interPlayerPlaybackRate !== playerPlaybackRate) {
-      sendMessage('seek', {
-        rate: interPlayerPlaybackRate,
-        time: currentTime,
-        state: playing ? 'playing' : '',
-      });
+    const isLatestTick = tickSeqRef.current === seq;
+
+    if (isPresenter && isLatestTick) {
+      // Emit at most one seek per tick. A real seek (position discontinuity) takes
+      // precedence over a bare playback-rate change and carries the real local position
+      // (state.playedSeconds) instead of the pre-seek, server-derived currentTime.
+      let seekMessage: { rate: number; time: number; state: string } | null = null;
+
+      // Detect a seek react-player did not surface via onSeek (every provider except
+      // FilePlayer, e.g. a YouTube scrub). Extrapolate the expected position from the last
+      // tick using the real playback rate, then use a SIGNED drift so the three cases stay
+      // separate: a jump AHEAD of the extrapolation is a fast-forward seek; a move BACKWARD
+      // past the last reported position is a backward seek; a playhead that advanced but by
+      // less than wall-clock predicted (drift < -threshold, still moving forward) is a stall,
+      // not a seek, and is left alone. This is why a backgrounded presenter tab does not yank
+      // every viewer backward, and why a small backward scrub is no longer silently dropped.
+      if (playing && baseline) {
+        const elapsedSeconds = (now - baseline.at) / 1000;
+        const expectedPosition = baseline.playedSeconds + (elapsedSeconds * interPlayerPlaybackRate);
+        const drift = state.playedSeconds - expectedPosition;
+        const jumpedAhead = drift > SEEK_DETECTION_THRESHOLD_SECONDS;
+        const jumpedBack = state.playedSeconds < baseline.playedSeconds - SEEK_DETECTION_THRESHOLD_SECONDS;
+        const discontinuity = jumpedAhead || jumpedBack;
+
+        const pending = pendingSeekRef.current;
+        if (pending) {
+          // Two-tick confirmation: broadcast only when this tick continues playback from the
+          // stashed discontinuity (it settled on a sustained position). A one-tick glitch
+          // (a YouTube ad boundary reporting the ad position near 0, or buffering) does not
+          // continue, so it is discarded here instead of yanking the whole meeting to 0:02
+          // and writing that into the recording. Rate-limited as insurance against a provider
+          // whose getCurrentTime oscillates.
+          const pendingElapsed = (now - pending.at) / 1000;
+          const expectedFromPending = pending.playedSeconds + (pendingElapsed * interPlayerPlaybackRate);
+          const confirmed = Math.abs(state.playedSeconds - expectedFromPending) <= SEEK_CONFIRMATION_THRESHOLD_SECONDS;
+          pendingSeekRef.current = null;
+          if (confirmed
+            && (now - lastSeekBroadcastAtRef.current) >= MIN_SEEK_BROADCAST_INTERVAL_SECONDS * 1000) {
+            seekMessage = {
+              rate: interPlayerPlaybackRate,
+              time: state.playedSeconds,
+              state: 'playing',
+            };
+            lastSeekBroadcastAtRef.current = now;
+          } else if (discontinuity) {
+            // Not the continuation we expected, but still discontinuous: re-arm on this new
+            // position so a genuine seek that landed mid-glitch is not lost.
+            pendingSeekRef.current = { playedSeconds: state.playedSeconds, at: now };
+          }
+        } else if (discontinuity) {
+          pendingSeekRef.current = { playedSeconds: state.playedSeconds, at: now };
+        }
+      }
+
+      if (!seekMessage && interPlayerPlaybackRate !== playerPlaybackRate) {
+        seekMessage = {
+          rate: interPlayerPlaybackRate,
+          time: currentTime,
+          state: playing ? 'playing' : '',
+        };
+      }
+
+      if (seekMessage) {
+        sendMessage('seek', seekMessage);
+      }
+    }
+
+    // Seed the baseline for the next tick, but only if this is still the latest tick and no
+    // interleaved handler advanced the baseline while we awaited the playback rate; otherwise
+    // a stale tick would clobber a synced handleOnSeek baseline and cause a duplicate emit.
+    if (isLatestTick && lastProgressRef.current === baseline) {
+      lastProgressRef.current = { playedSeconds: state.playedSeconds, at: now };
     }
 
     const storedVolume = storage.getItem('externalVideoVolume');
@@ -545,6 +704,14 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
         position: typeof cursor === 'number' ? cursor : cursor.position,
         updateAt: Date.now(),
       };
+      // Sync the progress baseline so the next handleProgress tick does not re-detect this
+      // same seek as a discontinuity and emit a duplicate, and drop any pending discontinuity
+      // this native seek supersedes.
+      lastProgressRef.current = {
+        playedSeconds: typeof cursor === 'number' ? cursor : cursor.position,
+        at: Date.now(),
+      };
+      pendingSeekRef.current = null;
     } else {
       playVideo(playerRef.current as ReactPlayer);
     }
@@ -627,6 +794,7 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
               url={playerUrl}
               playing={playing}
               playbackRate={playerPlaybackRate}
+              progressInterval={PROGRESS_INTERVAL_SECONDS * 1000}
               key={playerKey}
               height="100%"
               width="100%"

--- a/bigbluebutton-html5/package-lock.json
+++ b/bigbluebutton-html5/package-lock.json
@@ -11715,9 +11715,9 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
     },
     "node_modules/linkify-it": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
-      "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+      "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
       "funding": [
         {
           "type": "github",

--- a/bigbluebutton-html5/package-lock.json
+++ b/bigbluebutton-html5/package-lock.json
@@ -9585,9 +9585,9 @@
       "dev": true
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "dev": true,
       "funding": [
         {

--- a/bigbluebutton-tests/playwright/package-lock.json
+++ b/bigbluebutton-tests/playwright/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@playwright/test": "^1.56.0",
         "@swc/core": "^1.13.5",
-        "axios": "^1.16.0",
+        "axios": "^1.18.0",
         "chalk": "^4.1.2",
         "deep-equal": "^2.2.3",
         "dotenv": "^16.4.5",
@@ -791,6 +791,18 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
@@ -993,13 +1005,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
-      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.0.tgz",
+      "integrity": "sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
     },
@@ -1330,7 +1343,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -2720,6 +2732,19 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/husky": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/husky/-/husky-1.3.1.tgz",
@@ -3532,7 +3557,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/natural-compare": {

--- a/bigbluebutton-tests/playwright/package.json
+++ b/bigbluebutton-tests/playwright/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@playwright/test": "^1.56.0",
-    "axios": "^1.16.0",
+    "axios": "^1.18.0",
     "chalk": "^4.1.2",
     "deep-equal": "^2.2.3",
     "dotenv": "^16.4.5",

--- a/bigbluebutton-tests/playwright/presentation/presentation.spec.ts
+++ b/bigbluebutton-tests/playwright/presentation/presentation.spec.ts
@@ -121,6 +121,18 @@ test.describe.parallel('Presentation', { tag: '@ci' }, () => {
       await presentation.startExternalVideo();
       await presentation.endExternalVideo();
     });
+
+    // https://github.com/bigbluebutton/bigbluebutton/issues/25472
+    // Regression: presenter scrubbing the external video while playing must broadcast the
+    // new position. Adapters like YouTube do not emit a seek event, so before the fix the
+    // viewer stayed stuck. Asserts the viewer's playhead follows the presenter's seek.
+    test('Seek external video while playing', async ({ browser, context, page }, testInfo) => {
+      linkIssue(25472);
+      const presentation = new Presentation(browser, context);
+      await presentation.initPages(page, testInfo);
+      await presentation.startExternalVideo();
+      await presentation.seekExternalVideoWhilePlaying();
+    });
   });
 
   test.describe.parallel('Manage', () => {

--- a/bigbluebutton-tests/playwright/presentation/presentation.ts
+++ b/bigbluebutton-tests/playwright/presentation/presentation.ts
@@ -190,6 +190,100 @@ export class Presentation extends MultiUsers {
     await this.modPage.hasElement(e.whiteboard, 'should display the whiteboard after stopping the external video');
   }
 
+  // Regression test for issue #25472: when the presenter scrubs the external video while
+  // it is playing, the new position must be broadcast so viewers follow. react-player only
+  // surfaces a native seek event for FilePlayer; every hosted provider (YouTube here, plus
+  // Vimeo, Twitch, etc.) does not, so the client detects the discontinuity in onProgress and
+  // re-broadcasts it. This test drives YouTube, the common case. We assert the behaviour
+  // users actually care about: the viewer's playhead advances to the presenter's new
+  // position. That is stronger than counting outbound mutations and immune to WebSocket
+  // timing. Assumes startExternalVideo() already shared the video (chained in the spec).
+  async seekExternalVideoWhilePlaying() {
+    const { externalVideoPlayer } = this.modPage.settings || {};
+    // startExternalVideo() already asserted the share button is absent when the feature is
+    // disabled; nothing to seek in that case.
+    if (!externalVideoPlayer) return;
+
+    // startExternalVideo() already fetched both frames and asserted the video element is
+    // present for moderator and viewer, so we only fetch the handles we need to drive here.
+    const modFrame = await this.modPage.getYoutubeFrame();
+    if (!modFrame) throw Error('Failed to get video frame element for moderator');
+    const userFrame = await this.userPage.getYoutubeFrame();
+    if (!userFrame) throw Error('Failed to get video frame element for attendee');
+
+    const readCurrentTime = (frame: typeof modFrame) =>
+      frame.frame.locator('video').evaluate((v: HTMLVideoElement) => v.currentTime);
+
+    // Let the video play a few onProgress ticks so the presenter's baseline is seeded. Poll
+    // for real advance (one tick is enough) instead of a fixed 15s wait, which cuts most of
+    // that time off this @ci test.
+    const playbackStart = await readCurrentTime(modFrame);
+    await expect
+      .poll(() => readCurrentTime(modFrame), {
+        message: 'moderator video should be playing before the seek',
+        timeout: ELEMENT_WAIT_EXTRA_LONG_TIME,
+      })
+      .toBeGreaterThan(playbackStart + 3);
+
+    // Derive the seek target from the real duration instead of a hardcoded value: if
+    // youtubeLink changes, a fixed target could exceed the video length, YouTube would clamp
+    // to the end and fire onEnded, nulling the baseline (an opaque failure). The guard also
+    // covers v.duration being NaN (metadata not loaded), which would otherwise yield
+    // seekTarget = NaN, a no-op seekTo, and an opaque toBeGreaterThan(NaN) failure.
+    const duration = await modFrame.frame.locator('video').evaluate((v: HTMLVideoElement) => v.duration);
+    expect(duration, 'fixture video must be long enough to seek within').toBeGreaterThan(120);
+    const seekTarget = Math.floor(duration * 0.75);
+
+    // Self-validate against a fixture swap: the seek target must be well ahead of where
+    // natural playback has reached, or "the viewer followed the seek" would be satisfied by
+    // ordinary playback and prove nothing.
+    const beforeSeek = await readCurrentTime(userFrame);
+    expect(seekTarget - beforeSeek, 'seek target must be far ahead of natural playback').toBeGreaterThan(60);
+
+    // Scrub the YouTube player forward while it is playing. This is the path that does not
+    // emit a react-player onSeek event (the root cause of #25472). Scope the iframe lookup to
+    // the shared-video container (e.youtubeFrame) for consistency with getYoutubeFrame.
+    await this.modPage.page.evaluate(
+      ({ target, frameSelector }) => {
+        const iframe = document.querySelector<HTMLIFrameElement>(`${frameSelector} iframe`);
+        if (iframe && iframe.contentWindow) {
+          iframe.contentWindow.postMessage(
+            JSON.stringify({ event: 'command', func: 'seekTo', args: [target, true] }),
+            '*',
+          );
+        }
+      },
+      { target: seekTarget, frameSelector: e.youtubeFrame },
+    );
+
+    // Assert the PRESENTER actually seeked before checking the viewer. If the postMessage
+    // silently no-ops (YouTube protocol change, enablejsapi regression, iframe not matched),
+    // failing here points at the command, not at a phantom "viewer did not follow" product bug.
+    await expect
+      .poll(() => readCurrentTime(modFrame), {
+        message: 'presenter should have seeked',
+        timeout: ELEMENT_WAIT_EXTRA_LONG_TIME,
+      })
+      .toBeGreaterThan(seekTarget - 5);
+
+    // YouTube re-buffers after a seek, so the viewer lands a little short of the target and
+    // then climbs; allow this much slack below the target when confirming the follow.
+    const VIEWER_FOLLOW_TOLERANCE_SECONDS = 15;
+    await expect
+      .poll(() => readCurrentTime(userFrame), {
+        message: 'viewer should follow the presenter mid-play external video seek',
+        timeout: ELEMENT_WAIT_EXTRA_LONG_TIME,
+      })
+      .toBeGreaterThan(seekTarget - VIEWER_FOLLOW_TOLERANCE_SECONDS);
+
+    // Upper-bound the viewer position so an overshoot to the end (which a one-sided lower
+    // bound would let pass) fails the test instead of reading as a follow.
+    const viewerAfter = await readCurrentTime(userFrame);
+    expect(viewerAfter, 'viewer should land near the seek target, not overshoot to the end').toBeLessThan(
+      seekTarget + 30,
+    );
+  }
+
   async uploadSinglePresentationTest() {
     // wait for whiteboard to load and no notifications
     await this.modPage.waitForSelector(e.whiteboard, ELEMENT_WAIT_LONGER_TIME);

--- a/docs/docs/administration/customize.md
+++ b/docs/docs/administration/customize.md
@@ -1569,6 +1569,7 @@ These configs can be set in `/etc/bigbluebutton/bbb-web.properties`. The table i
 | `learningDashboardCleanupDelayInMinutes` | Minutes the Learning Dashboard remains available after the meeting ends | Integer (0=keep permanently) | 2 _`overwritable`_ |
 | `disabledFeatures` | Comma-separated list of features to disable (see [`/create` docs](/development/api/#create) for the full list of feature names) | csv | _(empty)_ _`overwritable`_ |
 | `sharedNotesEditor` | Type of shared notes editor to use | etherpad, blockNote | etherpad _`overwritable`_ |
+| `maxSharedNotesInitialContentUrlPayloadSize` | Maximum size (in KiB) of the response fetched when seeding shared-notes initial content from `sharedNotesInitialContentJsonUrl` / `sharedNotesInitialContentMarkdownUrl` | Integer (KiB) | 1024 |
 | `allowOverrideClientSettingsOnCreateCall` | Allow `clientSettingsOverride` / `clientSettingsOverrideJsonUrl` to be passed on `/create` | true/false | false |
 | `clientSettingsOverrideStrictValidation` | When true, reject the `/create` call (`bbb-web`) and refuse `bbb-apps-akka` boot if a client settings override has unknown or malformed keys. Intended for test/staging (see [Validating client settings overrides](#validating-client-settings-overrides)) | true/false | false |
 | `clientSettingsFilePath` | Path to the `settings.yml` catalog used as the schema for the strict client-settings override validation above | path | `/usr/share/bigbluebutton/html5-client/private/config/settings.yml` |

--- a/docs/docs/data/create.tsx
+++ b/docs/docs/data/create.tsx
@@ -390,13 +390,13 @@ const createEndpointTableData = [
     "name": "sharedNotesInitialContentMarkdown",
     "required": false,
     "type": "String",
-    "description": (<>Raw markdown used as the shared-notes initial content (Only applicable for when `sharedNotesEditor=blockNote`, ignored otherwise). Takes precedence over `sharedNotesInitialContentMarkdownUrl` when both are provided.</>)
+    "description": (<>Raw markdown used as the shared-notes initial content (Only applicable for when `sharedNotesEditor=blockNote`, ignored otherwise). When `sharedNotesInitialContentMarkdownUrl` is also provided, the URL takes precedence over this inline value; this inline parameter in turn takes precedence over the `sharedNotesInitialContentMarkdown` POST module.</>)
   },
   {
     "name": "sharedNotesInitialContentMarkdownUrl",
     "required": false,
     "type": "String",
-    "description": (<>Url from which the shared-notes will fetch the initial content as markdown (Only applicable for when `sharedNotesEditor=blockNote`, ignored otherwise). The URL must be `https` (`fetchUrlSupportedProtocols`), is capped by `maxSharedNotesInitialContentUrlPayloadSize` (default 1024 KiB) and has a 6000 ms timeout; a URL that violates these yields empty initial content silently.</>)
+    "description": (<>Url from which the shared-notes will fetch the initial content as markdown (Only applicable for when `sharedNotesEditor=blockNote`, ignored otherwise). When provided, it takes precedence over the inline `sharedNotesInitialContentMarkdown` create parameter and POST module. The URL must be `https` (`fetchUrlSupportedProtocols`), is capped by `maxSharedNotesInitialContentUrlPayloadSize` (default 1024 KiB) and has a 6000 ms timeout; a URL that violates these yields empty initial content silently.</>)
   },
   {
     "name": "disabledFeatures",

--- a/docs/docs/data/create.tsx
+++ b/docs/docs/data/create.tsx
@@ -77,6 +77,12 @@ const createEndpointTableData = [
     "description": (<>The URL that the BigBlueButton client will go to after users click the OK button on the ‘You have been logged out message’.  This overrides the value for <code className="language-plaintext highlighter-rouge">bigbluebutton.web.logoutURL</code> in <a href="https://github.com/bigbluebutton/bigbluebutton/blob/master/bigbluebutton-web/grails-app/conf/bigbluebutton.properties">bigbluebutton.properties</a>.</>)
   },
   {
+    "name": "meetingEndedURL",
+    "required": false,
+    "type": "String",
+    "description": (<>Server-to-server callback URL that BigBlueButton will invoke when the meeting ends. Useful for third-party integrations that need to react to meeting termination. (added 2.2)</>)
+  },
+  {
     "name": "record",
     "required": false,
     "type": "Boolean",
@@ -125,6 +131,30 @@ const createEndpointTableData = [
     "type": "Boolean",
     "default": false,
     "description": (<>If set to false, breakout rooms will not be recorded.</>)
+  },
+  {
+    "name": "breakoutRoomsCaptureSlides",
+    "required": false,
+    "type": "Boolean",
+    "description": (<>If set to <code className="language-plaintext highlighter-rouge">true</code>, the current slide (with annotations) from each breakout room is exported back to the parent meeting's presentation when the breakout ends. The server-side default is taken from <code className="language-plaintext highlighter-rouge">defaultBreakoutRoomsCaptureSlides</code>. (added 2.6)</>)
+  },
+  {
+    "name": "breakoutRoomsCaptureSlidesFilename",
+    "required": false,
+    "type": "String",
+    "description": (<>Filename template for slides captured from breakout rooms when <code className="language-plaintext highlighter-rouge">breakoutRoomsCaptureSlides=true</code>. (added 2.6)</>)
+  },
+  {
+    "name": "breakoutRoomsCaptureNotes",
+    "required": false,
+    "type": "Boolean",
+    "description": (<>If set to <code className="language-plaintext highlighter-rouge">true</code>, the shared notes from each breakout room are exported back to the parent meeting's presentation when the breakout ends. The server-side default is taken from <code className="language-plaintext highlighter-rouge">defaultBreakoutRoomsCaptureNotes</code>. (added 2.6)</>)
+  },
+  {
+    "name": "breakoutRoomsCaptureNotesFilename",
+    "required": false,
+    "type": "String",
+    "description": (<>Filename template for shared notes captured from breakout rooms when <code className="language-plaintext highlighter-rouge">breakoutRoomsCaptureNotes=true</code>. (added 2.6)</>)
   },
   {
     "name": "meta",
@@ -240,7 +270,7 @@ const createEndpointTableData = [
     "required": false,
     "type": "Boolean",
     "default": false,
-    "description": (<>Setting to <code className="language-plaintext highlighter-rouge">true</code> will disable notes in the meeting. (added 2.2)</>)
+    "description": (<>Setting to <code className="language-plaintext highlighter-rouge">true</code> will disable notes in the meeting. (added 2.2)<br /><br /><i>Note:</i> <code className="language-plaintext highlighter-rouge">lockSettingsDisableNote</code> (singular) is accepted as a deprecated alias and logs a deprecation warning on the server.</>)
   },
   {
     "name": "lockSettingsHideUserList",
@@ -348,6 +378,30 @@ const createEndpointTableData = [
     "description": (<>Setting to <code className="language-plaintext highlighter-rouge">0</code> will disable this threshold. Defines the max number of webcams a meeting can have simultaneously. (added 2.5.0)</>)
   },
   {
+    "name": "maxPinnedCameras",
+    "required": false,
+    "type": "Number",
+    "description": (<>Per-meeting override of the <code className="language-plaintext highlighter-rouge">maxPinnedCameras</code> property in <code className="language-plaintext highlighter-rouge">bigbluebutton.properties</code>. Caps how many cameras can be pinned simultaneously in this meeting. Only positive values are applied. (added 2.6)</>)
+  },
+  {
+    "name": "cameraBridge",
+    "required": false,
+    "type": "String",
+    "description": (<>Per-meeting override of the <code className="language-plaintext highlighter-rouge">cameraBridge</code> property. Selects the media bridge used for camera streams. Valid values: <code className="language-plaintext highlighter-rouge">bbb-webrtc-sfu</code>, <code className="language-plaintext highlighter-rouge">livekit</code>. (added 3.0)</>)
+  },
+  {
+    "name": "screenShareBridge",
+    "required": false,
+    "type": "String",
+    "description": (<>Per-meeting override of the <code className="language-plaintext highlighter-rouge">screenShareBridge</code> property. Selects the media bridge used for screen share streams. Valid values: <code className="language-plaintext highlighter-rouge">bbb-webrtc-sfu</code>, <code className="language-plaintext highlighter-rouge">livekit</code>. (added 3.0)</>)
+  },
+  {
+    "name": "audioBridge",
+    "required": false,
+    "type": "String",
+    "description": (<>Per-meeting override of the <code className="language-plaintext highlighter-rouge">audioBridge</code> property. Selects the media bridge used for audio streams. Valid values: <code className="language-plaintext highlighter-rouge">bbb-webrtc-sfu</code>, <code className="language-plaintext highlighter-rouge">livekit</code>, <code className="language-plaintext highlighter-rouge">freeswitch</code>. (added 3.0)</>)
+  },
+  {
     "name": "meetingExpireIfNoUserJoinedInMinutes",
     "required": false,
     "type": "Number",
@@ -372,6 +426,12 @@ const createEndpointTableData = [
     "required": false,
     "type": "String",
     "description": (<>Pass a URL to an image which will then be visible in the area above the participants list if <code>displayBrandingArea</code> is set to <code>true</code> in bbb-html5's configuration</>)
+  },
+  {
+    "name": "darklogo",
+    "required": false,
+    "type": "String",
+    "description": (<>Like <code className="language-plaintext highlighter-rouge">logo</code>, but used when the client is in dark mode. If only <code className="language-plaintext highlighter-rouge">logo</code> is provided, it is used in both light and dark modes. (added 3.0)</>)
   },
   {
     "name": "sharedNotesEditor",

--- a/docs/docs/development/api.md
+++ b/docs/docs/development/api.md
@@ -71,7 +71,7 @@ Updated in 2.0:
 
 Updated in 2.2:
 
-- **create** - Added `endWhenNoModerator`.
+- **create** - Added `endWhenNoModerator`, `meetingEndedURL`.
 - **getRecordingTextTracks** - Get a list of the caption/subtitle files currently available for a recording.
 - **putRecordingTextTrack** - Upload a caption or subtitle file to add it to the recording. If there is any existing track with the same values for kind and lang, it will be replaced.
 
@@ -99,7 +99,7 @@ Updated in 2.5:
 
 Updated in 2.6:
 
-- **create** - **Added:** `notifyRecordingIsOn`, `presentationUploadExternalUrl`, `presentationUploadExternalDescription`, `recordFullDurationMedia` (v2.6.9); `disabledFeaturesExclude`(2.6.9); Added `liveTranscription` and `presentation` as options for `disabledFeatures`.
+- **create** - **Added:** `notifyRecordingIsOn`, `presentationUploadExternalUrl`, `presentationUploadExternalDescription`, `recordFullDurationMedia` (v2.6.9); `disabledFeaturesExclude`(2.6.9); `maxPinnedCameras`, `breakoutRoomsCaptureSlides`, `breakoutRoomsCaptureSlidesFilename`, `breakoutRoomsCaptureNotes`, `breakoutRoomsCaptureNotesFilename`; Added `liveTranscription` and `presentation` as options for `disabledFeatures`.
 
 - **getRecordings** - **Added:** Added support for pagination using `offset`, `limit`
 
@@ -114,7 +114,7 @@ Updated in 2.7:
 Updated in 3.0:
 
 - **create**
-  - **Added parameters:** `loginURL`, `pluginManifests`, `pluginManifestsFetchUrl`, `presentationConversionCacheEnabled`, `maxNumPages`, `multiUserWhiteboardEnabled`, `clientSettingsOverrideJsonUrl`, `sharedNotesEditor`.
+  - **Added parameters:** `loginURL`, `pluginManifests`, `pluginManifestsFetchUrl`, `presentationConversionCacheEnabled`, `maxNumPages`, `multiUserWhiteboardEnabled`, `clientSettingsOverrideJsonUrl`, `sharedNotesEditor`, `cameraBridge`, `screenShareBridge`, `audioBridge`, `darklogo`.
   - **Added options:** Parameter `meetingLayout` supports a few new options: CAMERAS_ONLY, PARTICIPANTS_AND_CHAT_ONLY, PRESENTATION_ONLY, MEDIA_ONLY;
   - **Added options:** Parameter `disabledFeatures` supports a few new options: `infiniteWhiteboard`, `deleteChatMessage`, `editChatMessage`, `replyChatMessage`, `chatMessageReactions`, `raiseHand`, `userReactions`, `chatEmojiPicker`, `quizzes`;
   - **Added POST module:** `clientSettingsOverride` (gated by the server-side setting `allowOverrideClientSettingsOnCreateCall` in `bbb-web.properties`);

--- a/docs/docs/new-features.md
+++ b/docs/docs/new-features.md
@@ -143,6 +143,25 @@ To enable it, you would first need to install the optional package via
 At this point you can use it in a specific session by passing `sharedNotesEditor=blockNote` on the `/create` call.
 If you have made up your mind and would like to use it for all sessions, add the same line (`sharedNotesEditor=blockNote`) to `/etc/bigbluebutton/bbb-web.properties` and restart BigBlueButton via `$ sudo bbb-conf --restart`
 
+#### Import and export BlockNote shared notes as Markdown
+
+The BlockNote shared notes editor can now exchange content as Markdown (available in BigBlueButton 3.0.33). From the shared notes options menu, the presenter can choose **Import from Markdown**, which opens a dialog to either upload a Markdown file (drag-and-drop or file picker) or paste Markdown directly. The imported content can be **appended** to the existing notes (the default, so importing never destroys what is already there) or **replace** the whole document. Separately, an **Export notes as Markdown** option downloads the current notes as a `.md` file.
+
+Both options are **disabled by default** in BigBlueButton 3.0 so that a minor upgrade does not add new menu buttons unexpectedly. Enable either or both in `/etc/bigbluebutton/bbb-html5.yml` and restart with `sudo bbb-conf --restart`:
+
+```yaml
+public:
+  sharedNotes:
+    importMarkdownEnabled: true
+    exportMarkdownEnabled: true
+```
+
+These toggles only affect the BlockNote editor; they are ignored when Etherpad is used.
+
+Integrations can also seed a session's shared notes with Markdown at creation time using the `sharedNotesInitialContentMarkdown` / `sharedNotesInitialContentMarkdownUrl` create parameters (or a `sharedNotesInitialContentMarkdown` POST module). See the [Create API parameters](/development/api/#get-post-create) for details.
+
+<!-- TODO add screenshot of the Import from Markdown dialog (append/replace + file upload) -->
+
 
 ### Engagement
 
@@ -307,6 +326,7 @@ For full details on what is new in BigBlueButton 3.0, see the release notes.
 
 
 Recent releases:
+- [3.0.33](https://github.com/bigbluebutton/bigbluebutton/releases/tag/v3.0.33)
 - [3.0.32](https://github.com/bigbluebutton/bigbluebutton/releases/tag/v3.0.32)
 - [3.0.31](https://github.com/bigbluebutton/bigbluebutton/releases/tag/v3.0.31)
 - [3.0.30](https://github.com/bigbluebutton/bigbluebutton/releases/tag/v3.0.30)
@@ -400,6 +420,11 @@ In BigBlueButton 3.0.0-alpha.5 we replaced the JOIN parameter `defaultLayout` wi
 
 - Client settings.yml: `showGuestLobbyWaitingQueuePosition`. Defaults to `true`
 
+#### Added new settings to enable Markdown import/export in shared notes
+
+- Client settings.yml: `public.sharedNotes.importMarkdownEnabled`. Defaults to `false`. When `true`, presenters see an **Import from Markdown** option in the BlockNote shared notes menu.
+- Client settings.yml: `public.sharedNotes.exportMarkdownEnabled`. Defaults to `false`. When `true`, an **Export notes as Markdown** option is shown in the BlockNote shared notes menu.
+
 #### Added new setting and userdata to allow skipping echo test if session has valid input/output devices stored
 
 - Client settings.yml: `skipEchoTestIfPreviousDevice`. Defaults to `false`
@@ -447,6 +472,7 @@ Modified/added events
 - `muteOnStart` default value changed to `true` - which helps now that `transparentListenOnly` is enabled by default too. See [PR 20848](https://github.com/bigbluebutton/bigbluebutton/issues/20848) for more info.
 - `insertDocumentSupportedProtocols` renamed to `fetchUrlSupportedProtocols`
 - `insertDocumentBlockedHosts` renamed to `fetchUrlBlockedExternalHosts`
+- `html5PluginSdkVersion` bumped to `0.0.103`
 
 #### Added
 - `pluginManifestFetchTimeout` added
@@ -499,6 +525,7 @@ Modified/added events
 - `pluginManifestCacheRefreshIntervalMinutes` added in BBB 3.0.27
 - `clientSettingsOverrideStrictValidation` added in BBB 3.0.30
 - `clientSettingsFilePath` added in BBB 3.0.30
+- `maxSharedNotesInitialContentUrlPayloadSize` added — caps the size (in KiB, default `1024`) of the response fetched by `sharedNotesInitialContentJsonUrl` / `sharedNotesInitialContentMarkdownUrl`
 
 ### Removed support for POST requests on `join` endpoint and Content-Type headers are now required
 

--- a/docs/docs/plugins.md
+++ b/docs/docs/plugins.md
@@ -829,6 +829,16 @@ That being said, here are the extensible areas we have so far:
 
 Mind that no plugin will interfere into another's extensible area. So feel free to set whatever you need into a certain plugin with no worries.
 
+#### Configurable button styles
+
+Plugin-provided **nav bar**, **actions bar**, and **presentation toolbar** buttons accept a few optional style fields that control the rendered button's shape. They are read when present and fall back to the previous defaults when omitted, so older plugin objects keep rendering exactly as before (requires plugin SDK `0.0.100` or later):
+
+- `color` — button color (e.g. `primary`, `default`). Default: `primary` in the nav bar and actions bar, `default` in the presentation toolbar.
+- `circle` — render as a circular icon button. Default: `true` in the actions bar, `false` in the presentation toolbar and nav-bar.
+- `hideLabel` — hide the text label and show only the icon. Default: `true` in the actions bar, `false` in the presentation toolbar and nav-bar.
+- `size` — button size (`sm`, `md`, `lg`). Default: `lg` in the actions bar, `md` in the presentation toolbar and nav-bar.
+- `style` — an inline CSS style object applied to the button.
+
 ### Auxiliaries:
 
 - `getSessionToken`: returns the user session token located on the user's URL.

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -18187,9 +18187,9 @@
       "license": "MIT"
     },
     "node_modules/svgo": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.3.3.tgz",
-      "integrity": "sha512-+wn7I4p7YgJhHs38k2TNjy1vCfPIfLIJWR5MnCStsN8WuuTcBnRKcMHQLMM2ijxGZmDoZwNv8ipl5aTTen62ng==",
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.3.4.tgz",
+      "integrity": "sha512-GsNRis4e8jxn2Y9ENz/8lbJ93CstG8svtMnuRaHbiF2LTJ5tK0/q3t/URPq9Zc7zVWBJnNnJMIp6bevK7bSmNg==",
       "license": "MIT",
       "dependencies": {
         "commander": "^7.2.0",

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -17708,9 +17708,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
-      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.10.0.tgz",
+      "integrity": "sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -9556,9 +9556,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -6658,9 +6658,9 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "1.20.5",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
-      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
+      "version": "1.20.6",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.6.tgz",
+      "integrity": "sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==",
       "license": "MIT",
       "dependencies": {
         "bytes": "~3.1.2",


### PR DESCRIPTION
## Summary

When the presenter scrubbed a shared external video while it was playing, viewers did not follow the seek: the new position only changed for the presenter. The seek is now detected from the playback position discontinuity that react-player reports through `onProgress` and re-broadcast, so viewers follow regardless of whether the underlying player adapter emits a native seek event.

Closes #25472

## Root Cause

react-player only fires `onSeek` for `FilePlayer` (the HTML5 media element, used for mp4 and audio). Every hosted provider (YouTube, Vimeo, Twitch, Facebook, DailyMotion) and all three BBB custom players (peertube, arc-player, panopto) never fire it, so a scrub performed on the embedded player never reaches the client `handleOnSeek`. A mid-play seek therefore sent no `externalVideoUpdate` mutation, and viewers (who only re-seek when `externalVideo.updatedAt` changes) stayed at the old position. The existing `handleProgress` broadcast a `seek` only on a playback rate change, never on a position discontinuity.

Because `onSeek` covers only `FilePlayer`, this `onProgress` detection is now the sole seek propagation path for nearly every supported provider, so its false-positive and false-negative behaviour is load-bearing, not a belt-and-braces addition.

Seek while paused already worked because both `stop` (pause) and `play` (resume) broadcast the current position. The gap was specific to a seek performed while playing on an adapter that lacks the native event.

## Implementation

`bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx`

Detection in `handleProgress` (presenter only): the expected position is extrapolated from the last progress tick using the real playback rate, and a seek is broadcast with the real local position (`state.playedSeconds`) when the reported position diverges past `SEEK_DETECTION_THRESHOLD_SECONDS` (2s). Hardening:

- **Signed drift predicate.** A jump ahead of the extrapolation is a fast-forward seek; a move backward past the last reported position is a backward seek; a playhead that advanced but by less than wall-clock predicted is a stall, not a seek, and is left alone. This keeps a backgrounded presenter tab (throttled timers) from yanking every viewer backward, and removes the old rate-dependent dead zone that silently dropped small backward scrubs.
- **Two-tick confirmation.** A detected discontinuity is stashed and only broadcast once the next tick confirms playback continued from it. A single-tick glitch such as a YouTube ad boundary (the IFrame API `getCurrentTime` returns the ad position near 0) or a buffering hiccup does not continue and is discarded, at the cost of about one second of viewer-follow latency.
- **Rate limit.** At most one detected seek is broadcast every 2s, as insurance against a provider whose `getCurrentTime` oscillates.
- **Concurrency guard.** A monotonic tick counter drops a stale `handleProgress` tick (`getPlaybackRate` is async for Vimeo, so two ticks can overlap) so it cannot emit a seek or seed the baseline.
- **Baseline lifecycle.** The baseline, the pending discontinuity and the playing mirror are reset on video change, player remount, start, pause and any presenter change, and the baseline is reset only on a genuine paused to playing transition (react-player re-fires `onPlay` after YouTube buffers on a far seek).
- **progressInterval** is passed to the player explicitly so a future prop change cannot silently halve the detector sensitivity.

## Test Coverage

`bigbluebutton-tests/playwright/presentation/presentation.spec.ts`: test `Seek external video while playing` (in the `External Video` describe block, `linkIssue(25472)`).

The test asserts the user-facing behaviour rather than counting mutations: the presenter is asserted to have actually seeked (so a silent no-op of the seek command fails on the command, not on a phantom "viewer did not follow" product bug), then the viewer video `currentTime` is polled until it follows to the new position. The seek target is derived from the real video duration and the test is self-validating against a fixture swap: it asserts the fixture is long enough to seek within (which also guards against a `NaN` duration) and that the target is far ahead of natural playback, so it cannot silently become vacuous. The viewer assertion is bounded on both sides so an overshoot to the end cannot pass.

## Manual Test Cases

| Scenario | Expected | Obtained (live, BBB 3.0 from-source) |
|---|---|---|
| Presenter scrubs YouTube forward while playing | Viewer follows to the new position | Viewer 171.7s to 322.4s, presenter 322.6s, follow gap 0.21s |
| Presenter scrubs YouTube backward while playing | Viewer follows backward | Viewer 322.4s to 110.4s, presenter 110.6s, follow gap 0.27s |
| Steady playback (no scrub) | Viewer keeps advancing, is never yanked | 8 samples over 8s advance monotonically (164s to 171.5s), max backward jump 0.0s |
| Presenter pauses then resumes | No spurious seek | Baseline and pending discontinuity reset on stop and on the paused to playing transition |
| Presenter changes the shared video | No spurious seek on the first tick | Video-change effect resets baseline, pending and the playing mirror |
| Viewer promoted to presenter | Cannot broadcast a seek from a stale position | Presenter-change effect resets baseline and pending |

## Evidence

Verified on a BBB 3.0 from-source environment (`v3.0.x-develop`), presenter and viewer in the same meeting sharing a YouTube video. The committed regression test passed on 4 consecutive runs.

- Forward seek: presenter and viewer both land on the same scene (`5:22 / 7:05`), follow gap 0.21s.
- Backward seek: presenter and viewer both land on the same earlier scene (`1:50 / 7:05`), follow gap 0.27s, confirming backward seeks propagate.
- Steady playback: the viewer playhead advances monotonically with no backward jump, confirming ordinary playback never triggers a spurious broadcast.

Animated preview below, click the GIF to open the MP4 (higher quality, with controls). Left is the presenter scrubbing the video, right is the viewer following.

[![Presenter seeks external video, viewer follows](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-07-23/64f145c5-5afd-4b9e-8202-f2b8e82dbd43/seek-follow.gif)](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-07-23/39515cdf-d63f-41ef-b3eb-c00ca7c0afd4/seek-follow.mp4)

## Risks/Notes

- **Sub-threshold scrubs (up to ~2s) are not broadcast** and nothing re-syncs the viewer position periodically (viewers only re-seek on an `updatedAt` change), so a missed scrub leaves viewers offset by that amount until the next above-threshold seek. This is a deliberate trade so tiny drags do not yank viewers.
- **Backgrounded-tab yank** is addressed by the signed predicate at the code level (a partial advance is classified as a stall). A tab throttled to one timer per minute could not be reproduced in a headless browser, so that specific path was validated by reasoning about the predicate rather than live.
- **Scope is 3.0 (`v3.0.x-develop`).** The 4.0 client has an equivalent `component.tsx` and likely the same defect; it is out of scope here per the issue version line and is a known limitation.
