### PR TITLE
refactor: remove deprecated copyright create parameter

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/ApiParams.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/ApiParams.java
@@ -31,7 +31,6 @@ public class ApiParams {
     public static final String BANNER_COLOR = "bannerColor";
     public static final String BANNER_TEXT = "bannerText";
     public static final String CHECKSUM = "checksum";
-    public static final String COPYRIGHT = "copyright";
     public static final String DIAL_NUMBER = "dialNumber";
     public static final String DURATION = "duration";
     public static final String FREE_JOIN = "freeJoin";

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
@@ -1093,9 +1093,6 @@ public class ParamsProcessorUtil {
             meeting.setCustomDarkLogoURL(this.getDefaultLogoURL());
         }
 
-		if (!StringUtils.isEmpty(params.get(ApiParams.COPYRIGHT))) {
-			meeting.setCustomCopyright(params.get(ApiParams.COPYRIGHT));
-		}
 		Boolean muteOnStart = defaultMuteOnStart;
 		if (!StringUtils.isEmpty(params.get(ApiParams.MUTE_ON_START))) {
         	muteOnStart = Boolean.parseBoolean(params.get(ApiParams.MUTE_ON_START));

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/Meeting.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/Meeting.java
@@ -109,7 +109,6 @@ public class Meeting {
 	private ArrayList<Group> groups = new ArrayList<Group>();
 	private String customLogoURL = "";
 	private String customDarkLogoURL = "";
-	private String customCopyright = "";
 	private Boolean muteOnStart = false;
 	private String cameraBridge = "livekit";
 	private String screenShareBridge = "livekit";
@@ -772,14 +771,6 @@ public class Meeting {
 
 	public void setCustomDarkLogoURL(String url) {
 		customDarkLogoURL = url;
-	}
-
-	public void setCustomCopyright(String copyright) {
-    	customCopyright = copyright;
-	}
-
-	public String getCustomCopyright() {
-    	return customCopyright;
 	}
 
 	public void setMuteOnStart(Boolean mute) {

--- a/docs/docs/development/api.md
+++ b/docs/docs/development/api.md
@@ -134,6 +134,7 @@ Updated in 4.0:
   - **Added parameters:** `requireUserConsentBeforeUnmuting` (only relevant when `allowModsToUnmuteUsers=true`; when `true`, the user is shown a consent dialog before a moderator can unmute them), `lockSettingsPresenterPolicy` (controls the "Request to Present" policy; one of `moderatorOnly`, `requireApproval` (default), `freeForAll`).
   - **Added options:** Parameter `disabledFeatures` supports new options: `multiFunctionalMode` (the auxiliary/dual sidebar panel) and `pinChatMessage`.
   - **Removed parameter:** `lockSettingsDisableNote` (singular); use `lockSettingsDisableNotes` (plural) instead.
+  - **Removed parameter:** `copyright` (it had no effect; the value was stored but never propagated to the client). To customize the copyright text per meeting, override `app.copyright` through `clientSettingsOverride` / `clientSettingsOverrideJsonUrl` (requires `allowOverrideClientSettingsOnCreateCall=true`).
   - **Changed:** Parameter `meetingLayout` default is now `UNIFIED_LAYOUT`. **Removed:** `meetingLayout` no longer supports `CUSTOM_LAYOUT`, `SMART_LAYOUT`, `PRESENTATION_FOCUS`, `VIDEO_FOCUS`. The remaining non-default options targeting hybrid/niche scenarios are `CAMERAS_ONLY`, `PARTICIPANTS_AND_CHAT_ONLY`, `PRESENTATION_ONLY`, `MEDIA_ONLY`.
   - **Removed option:** `layouts` is no longer a valid `disabledFeatures` value (the layout selection UI was removed).
 - **join**


### PR DESCRIPTION
## Summary

The `/create` API parameter `copyright` was parsed by bbb-web and stored on the
`Meeting` object (`customCopyright`), but the value was never forwarded to
akka-apps or to the client, so setting `copyright=` on `/create` had no
observable effect. This PR removes the dead parameter and its backing field.

Removing it loses no capability. The copyright string shown in the client's
About dialog is sourced from client settings (`app.copyright`), and that value
is already overridable per meeting through the existing `clientSettingsOverride`
/ `clientSettingsOverrideJsonUrl` mechanism (behind the admin flag
`allowOverrideClientSettingsOnCreateCall=true`).

Impact for users/integrations: none. Callers that still send `copyright=X`
continue to receive a `SUCCESS` response (the checksum covers the whole query
string regardless of whether bbb-web recognizes the parameter); the parameter is
simply ignored, exactly as it already was.

Resolves issue #25431.

## Root Cause

This is a cleanup rather than a bug fix, so "root cause" here is the history of
how the parameter became dead code:

- 2017 (`d09abe92e4`, "allow to pass custom copyright text using create API"):
  the parameter was introduced for the Flash client, which received the value
  through the `/enter` endpoint response.
- 2020 (`143d9bbe87`, "Removed obsolete BBB components from 2.3"): the Flash
  client was deleted, removing the only consumer of the value.
- 2024 (`25857dc509`, "Remove endpoint /enter of bbb-web"): the last
  server-side reader (`customCopyright = meeting.getCustomCopyright()` in the
  `/enter` response) was removed. Since then the field has been write-only:
  `getCustomCopyright()` has zero callers, no `*Props` case class carries a
  `copyright` field, and `customCopyright` appears nowhere in
  `bbb-common-message`, `akka-bbb-apps`, or `bigbluebutton-html5`.

## Implementation

Removed the parameter at its three sites in `bbb-common-web` and documented the
removal in the API changelog. Chose removal over "finish implementing the
parameter" (the alternative raised in the issue) because the capability already
exists and works: the client renders `app.copyright`, which is overridable per
meeting via `clientSettingsOverride` / `clientSettingsOverrideJsonUrl`.
Implementing propagation would build a second, redundant path to a value the
client-settings override already controls.

Files changed:

- `bbb-common-web/.../api/ApiParams.java` - dropped the `COPYRIGHT` constant.
  It named the dead parameter; with no consumers it is unused.
- `bbb-common-web/.../api/ParamsProcessorUtil.java` - dropped the block that
  copied the parameter onto the `Meeting` (`setCustomCopyright(...)`). This was
  the write that led nowhere.
- `bbb-common-web/.../api/domain/Meeting.java` - dropped the `customCopyright`
  field and its unused setter/getter. No `Meeting.Builder` entry existed.
- `docs/docs/development/api.md` - added the removal to the "Updated in 4.0:"
  create changelog, pointing to the client-settings override as the supported
  replacement.

Neighboring `/create` parameters (`logo` / `darklogo` / `muteOnStart`), which
sit immediately around every edited site, are untouched.

## Test Coverage

No automated test was added. The parameter is a no-op in the current codebase,
so there is no behavior a test could assert as "red before, green after"; a test
would only encode the absence of a symbol, which the compiler and the acceptance
greps already guarantee. This falls under the project's guidance that
deploy/config/no-op-removal changes may be validated by build + manual gates
rather than a new automated test. An optional Playwright spec asserting the
`app.copyright` override was considered and deliberately left out as scope creep
beyond the issue's acceptance criteria (the override path is already exercised by
the existing `breakout/clientSettingsOverride.ts` E2E helper, and CI already
enables the gate).

Validation performed on a from-source `v4.0.x-develop` build:

- Acceptance greps drop to zero: `git grep -i customCopyright` 6 -> 0;
  `git grep COPYRIGHT -- bbb-common-web` 3 -> 0.
- `bbb-common-web` and `bbb-web` build green; `bbb-web` restarts clean and
  serves the API.
- The rebuilt `bbb-common-web` jar deployed into the running server no longer
  contains the `CustomCopyright` symbols (2 -> 0), confirming the change reached
  the running artifact.

## Manual Test Cases

| Scenario | Expected | Observed |
|---|---|---|
| `/create` with `copyright=SomeCorp` (legacy caller), after removal | `SUCCESS`, meeting joinable, About shows default | `SUCCESS`; About shows (c)2026 BigBlueButton Inc. |
| No override, default settings | About shows default copyright | Matches |
| `clientSettingsOverride` for `app.copyright`, gate `allowOverrideClientSettingsOnCreateCall=false` | Override ignored, default shown | Default shown (ignored) |
| `clientSettingsOverride` for `app.copyright`, gate `=true` | About shows overridden value | About shows overridden value |
| `getMeetingInfo` / `getMeetings` responses | Unchanged (never exposed `customCopyright`) | Unchanged |

## Evidence

About dialog with no override (default `app.copyright`), confirming the client
still renders the copyright string after the parameter removal:

![About dialog showing the default copyright string after the parameter removal](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-07-31/75dc6fe7-4178-42ad-8210-23d128b43041/about_default.png)

About dialog with a per-meeting override via `clientSettingsOverride` (gate on),
confirming the replacement capability is user-visible:

![About dialog showing an overridden copyright string via clientSettingsOverride](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-07-31/5edb2b26-f6f0-4497-8bdb-264b97d66eb3/about_override.png)

The overridden value was also read back from the live client
(`window.meetingClientSettings.public.app.copyright`) and from the
`meeting_clientSettings.clientSettingsJson` row, which is the exact JSON the
client loads.

## Risks / Notes

- Not a breaking change: the parameter has been silently ignored since 2020, and
  callers sending it still receive `SUCCESS`.
- `docs/docs/data/create.tsx` is intentionally untouched: it has no `copyright`
  entry to remove, and adding one belongs only to the not-chosen "implement the
  parameter" alternative.
- `docs/docs/development/api.md:68` (the historical 2.0 "Added ... copyright"
  changelog line) is intentionally left in place as history.
- `new-features.md` was intentionally not edited: the issue asks only for the API
  changelog (`api.md`), and the existing `#### Removed` buckets in
  `new-features.md` are for bbb-web properties / client settings, not pure API
  parameters.
- Out of scope, noted for a maintainer: a stray `println(...)` sits in the
  `clientSettingsOverride` POST-body path in `ApiController.groovy`. Left as is
  to keep this change focused.
