### PR TITLE
Fix BlockNote side menu visibility outside shared notes editor

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
@@ -471,7 +471,8 @@ function BlockNoteApp(props: BlockNoteAppProps): React.ReactElement {
           /* BlockNote hardcodes side-menu heights for its default typography.
              Let the controls keep their natural height when BBB typography changes
              the corresponding block height (https://github.com/TypeCellOS/BlockNote/issues/2224). */
-          .bn-side-menu[data-block-type="heading"],
+          .bn-side-menu,
+          .bn-side-menu[data-block-type="heading"][data-level],
           .bn-side-menu[data-block-type="file"],
           .bn-side-menu[data-block-type="audio"],
           .bn-side-menu[data-url="false"] {

--- a/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
@@ -6,6 +6,7 @@ import { BlockNoteSchema, defaultBlockSpecs } from '@blocknote/core';
 // As of BlockNote 0.53, `collaboration` is no longer a `BlockNoteEditorOptions` field:
 // it ships as an extension behind the `@blocknote/core/yjs` subpath
 import { withCollaboration } from '@blocknote/core/yjs';
+import { SideMenuExtension } from '@blocknote/core/extensions';
 import '@blocknote/mantine/style.css';
 import { HocuspocusProvider } from '@hocuspocus/provider';
 import { Awareness } from 'y-protocols/awareness';
@@ -348,6 +349,7 @@ function BlockNoteApp(props: BlockNoteAppProps): React.ReactElement {
   // Keep the editor's focus/selection when tapping a toolbar button by
   // cancelling the default focus move on mousedown.
   const toolbarRef = React.useRef<HTMLDivElement>(null);
+  const wrapperRef = React.useRef<HTMLDivElement>(null);
   React.useEffect(() => {
     const el = toolbarRef.current;
     if (!el) return undefined;
@@ -376,8 +378,21 @@ function BlockNoteApp(props: BlockNoteAppProps): React.ReactElement {
     };
   }, [editor]);
 
+  // TODO: Remove this workaround when BlockNote limits side-menu detection to the editor.
+  // Related upstream issues: https://github.com/TypeCellOS/BlockNote/issues/1016 and
+  // https://github.com/TypeCellOS/BlockNote/issues/351.
+  React.useEffect(() => {
+    const mousemoveHandler = (event: MouseEvent) => {
+      if (!wrapperRef.current?.contains(event.target as Node)) {
+        editor.getExtension(SideMenuExtension)?.hideMenuIfNotFrozen();
+      }
+    };
+    document.addEventListener('mousemove', mousemoveHandler);
+    return () => document.removeEventListener('mousemove', mousemoveHandler);
+  }, [editor]);
+
   return (
-    <div style={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
+    <div ref={wrapperRef} style={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
       <style>
         {`
           /* BlockNote ships Inter and hardcodes it; inherit the client font
@@ -452,6 +467,15 @@ function BlockNoteApp(props: BlockNoteAppProps): React.ReactElement {
             flex: 1 1 0;
             min-height: 0;
             overflow-y: auto;
+          }
+          /* BlockNote hardcodes side-menu heights for its default typography.
+             Let the controls keep their natural height when BBB typography changes
+             the corresponding block height (https://github.com/TypeCellOS/BlockNote/issues/2224). */
+          .bn-side-menu[data-block-type="heading"],
+          .bn-side-menu[data-block-type="file"],
+          .bn-side-menu[data-block-type="audio"],
+          .bn-side-menu[data-url="false"] {
+            height: auto;
           }
           /* Flip labels to below when near top of scroll container */
           .bn-block-group > .bn-block-outer:first-child

--- a/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
@@ -468,13 +468,10 @@ function BlockNoteApp(props: BlockNoteAppProps): React.ReactElement {
             min-height: 0;
             overflow-y: auto;
           }
-          /* BlockNote hardcodes side-menu heights for its default typography.
-             Let the controls keep their natural height when BBB typography changes
-             the corresponding block height (https://github.com/TypeCellOS/BlockNote/issues/2224). */
-          .bn-side-menu,
-          .bn-side-menu[data-block-type="heading"][data-level] {
-            height: auto;
-          }
+          /* BlockNote 0.53 centers the side menu with floating-ui offsets that
+             assume its default 30px height, so overriding the height would
+             misalign heading drag handles. Historical context:
+             https://github.com/TypeCellOS/BlockNote/issues/2224. */
           /* Flip labels to below when near top of scroll container */
           .bn-block-group > .bn-block-outer:first-child
             .bn-collaboration-cursor__label {

--- a/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
@@ -382,8 +382,8 @@ function BlockNoteApp(props: BlockNoteAppProps): React.ReactElement {
   // Related upstream issues: https://github.com/TypeCellOS/BlockNote/issues/1016 and
   // https://github.com/TypeCellOS/BlockNote/issues/351.
   React.useEffect(() => {
-    const mousemoveHandler = (event: MouseEvent) => {
-      if (!wrapperRef.current?.contains(event.target as Node)) {
+    const mousemoveHandler = (e: MouseEvent) => {
+      if (!wrapperRef.current?.contains(e.target as Node)) {
         editor.getExtension(SideMenuExtension)?.hideMenuIfNotFrozen();
       }
     };
@@ -472,10 +472,7 @@ function BlockNoteApp(props: BlockNoteAppProps): React.ReactElement {
              Let the controls keep their natural height when BBB typography changes
              the corresponding block height (https://github.com/TypeCellOS/BlockNote/issues/2224). */
           .bn-side-menu,
-          .bn-side-menu[data-block-type="heading"][data-level],
-          .bn-side-menu[data-block-type="file"],
-          .bn-side-menu[data-block-type="audio"],
-          .bn-side-menu[data-url="false"] {
+          .bn-side-menu[data-block-type="heading"][data-level] {
             height: auto;
           }
           /* Flip labels to below when near top of scroll container */

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-form/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-form/styles.ts
@@ -192,14 +192,6 @@ const InputWrapper = styled.div`
   gap: 3px;
   cursor: text;
 
-  [dir='ltr'] & {
-    border-radius: 0.75rem 0 0 0.75rem;
-  }
-
-  [dir='rtl'] & {
-    border-radius: 0 0.75rem 0.75rem 0;
-  }
-
   &:focus-within {
     border-color: ${colorPrimary};
     box-shadow: 0 0 0 ${xsPadding} ${colorBorder};

--- a/bigbluebutton-tests/playwright/core/elements.ts
+++ b/bigbluebutton-tests/playwright/core/elements.ts
@@ -314,6 +314,7 @@ export const elements = {
   blockNoteEditor: '#bn-notes-scroll-container .bn-editor',
   blockNoteEditable: '#bn-notes-scroll-container .bn-editor[contenteditable="true"]',
   blockNoteReadOnly: '#bn-notes-scroll-container .bn-editor[contenteditable="false"]',
+  blockNoteSideMenu: '#bn-notes-scroll-container .bn-side-menu',
   blockNoteToolbar: 'div[data-test="blockNoteToolbar"]',
   blockNoteUnderlineButton: 'div[data-test="blockNoteToolbar"] button[aria-label="Underline"]',
   blockNoteAlignTextLeftButton: 'div[data-test="blockNoteToolbar"] button[aria-label="Align text left"]',

--- a/bigbluebutton-tests/playwright/sharednotes/blocknote/blocknote.spec.ts
+++ b/bigbluebutton-tests/playwright/sharednotes/blocknote/blocknote.spec.ts
@@ -19,4 +19,8 @@ test.describe.parallel('Shared Notes - BlockNote', { tag: '@ci' }, () => {
   test("Collaboration cursor must not embed a user's name in a link", async () => {
     await blockNoteSharedNotes.collaborationCursorMustNotEmbedInLink();
   });
+
+  test('Side menu must hide outside the editor', async () => {
+    await blockNoteSharedNotes.sideMenuMustHideOutsideEditor();
+  });
 });

--- a/bigbluebutton-tests/playwright/sharednotes/blocknote/blocknote.ts
+++ b/bigbluebutton-tests/playwright/sharednotes/blocknote/blocknote.ts
@@ -43,6 +43,8 @@ export class BlockNoteSharedNotes extends MultiUsers {
 
     await this.modPage.page.mouse.move(editorBox.x + editorBox.width + 130, blockY);
     await expect(sideMenu, 'should keep the side menu hidden on later mouse movement outside the editor').toBeHidden();
+
+    await this.modPage.waitAndClick(e.hideNotesLabel);
   }
 
   // Reproduces issue #25225: when a remote user's caret sits inside a link, that

--- a/bigbluebutton-tests/playwright/sharednotes/blocknote/blocknote.ts
+++ b/bigbluebutton-tests/playwright/sharednotes/blocknote/blocknote.ts
@@ -15,6 +15,36 @@ import {
 const LINK_URL = 'https://github.com/bigbluebutton/bigbluebutton/issues/25175';
 
 export class BlockNoteSharedNotes extends MultiUsers {
+  async sideMenuMustHideOutsideEditor() {
+    await startBlockNoteSharedNotes(this.modPage);
+
+    const editor = getBlockNoteEditorLocator(this.modPage);
+    await editor.click();
+    await this.modPage.page.keyboard.type('First block');
+    await this.modPage.page.keyboard.press('Enter');
+    await this.modPage.page.keyboard.type('Second block');
+
+    const firstBlock = editor.locator('.bn-block-outer').first();
+    const editorBox = await editor.boundingBox();
+    const firstBlockBox = await firstBlock.boundingBox();
+    expect(editorBox, 'BlockNote editor should have a bounding box').not.toBeNull();
+    expect(firstBlockBox, 'first BlockNote block should have a bounding box').not.toBeNull();
+    if (!editorBox || !firstBlockBox) return;
+
+    const blockY = firstBlockBox.y + firstBlockBox.height / 2;
+    await this.modPage.page.mouse.move(firstBlockBox.x + firstBlockBox.width / 2, blockY);
+    const sideMenu = this.modPage.page.locator(e.blockNoteSideMenu);
+    await expect(sideMenu, 'should display the side menu while hovering a block').toBeVisible();
+
+    // Regression test for #25575: BlockNote listens for mouse movement on the
+    // whole document and used to re-open the menu near a block, outside the editor.
+    await this.modPage.page.mouse.move(editorBox.x + editorBox.width + 120, blockY);
+    await expect(sideMenu, 'should hide the side menu outside the editor').toBeHidden();
+
+    await this.modPage.page.mouse.move(editorBox.x + editorBox.width + 130, blockY);
+    await expect(sideMenu, 'should keep the side menu hidden on later mouse movement outside the editor').toBeHidden();
+  }
+
   // Reproduces issue #25225: when a remote user's caret sits inside a link, that
   // user's collaboration-cursor name (and the U+2060 word-joiner separators around
   // it) must NOT be embedded in the link's text or href as seen by other users.

--- a/bigbluebutton-tests/playwright/sharednotes/blocknote/blocknote.ts
+++ b/bigbluebutton-tests/playwright/sharednotes/blocknote/blocknote.ts
@@ -44,6 +44,18 @@ export class BlockNoteSharedNotes extends MultiUsers {
     await this.modPage.page.mouse.move(editorBox.x + editorBox.width + 130, blockY);
     await expect(sideMenu, 'should keep the side menu hidden on later mouse movement outside the editor').toBeHidden();
 
+    await this.modPage.page.mouse.move(firstBlockBox.x + firstBlockBox.width / 2, blockY);
+    const dragHandle = sideMenu.getByRole('button', { name: 'Open block menu' });
+    await expect(dragHandle, 'should display the drag handle inside the editor').toBeVisible();
+    await dragHandle.click();
+    const blockMenu = this.modPage.page.getByRole('menu');
+    await expect(blockMenu, 'should open the block menu from the drag handle').toBeVisible();
+
+    await this.modPage.page.mouse.move(editorBox.x + editorBox.width + 120, blockY);
+    await expect(sideMenu, 'should keep the frozen side menu visible outside the editor').toBeVisible();
+    await expect(blockMenu, 'should keep the frozen block menu open outside the editor').toBeVisible();
+    await this.modPage.page.keyboard.press('Escape');
+
     await this.modPage.waitAndClick(e.hideNotesLabel);
   }
 


### PR DESCRIPTION
## Summary

BlockNote displayed its add and drag buttons when the pointer was outside the Shared Notes editor but remained near a block on the same vertical position.

Closes #25575

This made the controls appear over unrelated interactions in the meeting UI. The side menu is now hidden while the pointer moves outside the complete Shared Notes editor panel, while preserving BlockNote's existing behavior inside the editor and while a drag-handle menu is frozen.

The change also overrides BlockNote's hard-coded side-menu heights for headings and media blocks. On the final bundle, H1, H2, and H3 side menus measured 24 px against blocks of 84 px, 63 px, and 48.3 px respectively, with no lower overflow. The file, audio, and missing-URL variants remain covered by the same override but were not successfully created by the post-fix probe.

## Root Cause

This behavior was reported on BlockNote 0.51.4 and persists on the currently bundled 0.53.0 (re-confirmed by the failing E2E run on the unmodified rebased client): BlockNote registers its side-menu `mousemove` listener on the document rather than on the editor. Its proximity algorithm considers blocks up to 250 pixels away without requiring the event target to belong to the editor.

As a result, moving over another part of the meeting UI at the same vertical position as a note block could keep the side menu visible or show it again after a one-time hide.

A one-time `pointerleave` handler was insufficient because the following document-level `mousemove` immediately restored the menu. This is upstream behavior tracked by TypeCellOS/BlockNote issues 1016 and 351, rather than a BBB-specific regression with a known introducing commit.

BlockNote also assigns fixed heights to side menus for headings and media blocks. Those values assume BlockNote's default typography and do not match the block dimensions after BBB's typography overrides. This upstream limitation is tracked by TypeCellOS/BlockNote issue 2224.

## Implementation

### `bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx`

- Added a ref around the complete BlockNote panel, including its toolbar and editor.
- Added a document-level bubbling `mousemove` listener.
- When the event target is outside the panel, the listener calls `SideMenuExtension.hideMenuIfNotFrozen()`.
- The listener runs after BlockNote's capture listener, providing sustained suppression for every outside movement.
- `hideMenuIfNotFrozen()` preserves an open drag-handle dropdown because BlockNote keeps the menu frozen while that dropdown is active.
- Added a TODO referencing the two upstream side-menu issues.
- Overrode the fixed heading, file, audio, and missing-URL side-menu heights with natural height. BlockNote 0.53 no longer renders `data-block-type`/`data-level` attributes on the side menu and ships a flat `.bn-side-menu { height: 30px }` rule, so a bare `.bn-side-menu` fallback selector was added to the same component style block; it matches the bundled rule specificity and wins by cascade order. The attribute-qualified selectors are retained for DOM variants that expose those attributes.

A CSS-only `:hover` rule was rejected because it would hide an open drag-handle dropdown, leave BlockNote's internal hovered-block state active, and rely on sticky hover behavior on touch devices.

### `bigbluebutton-tests/playwright/core/elements.ts`

Added the BlockNote side-menu selector used by the regression test.

### `bigbluebutton-tests/playwright/sharednotes/blocknote/blocknote.ts`

Added an end-to-end scenario that types two blocks and moves the real Playwright mouse:

1. Over the first block, where the side menu must be visible.
2. 120 pixels outside the editor at the same vertical position, where it must be hidden.
3. Another 10 pixels outside, where it must remain hidden despite BlockNote processing a second document-level movement.

### `bigbluebutton-tests/playwright/sharednotes/blocknote/blocknote.spec.ts`

Registered the new regression scenario in the existing `@ci` BlockNote suite.

## Test Coverage

### `Side menu must hide outside the editor`

The test uses actual `page.mouse.move()` coordinates obtained from the editor and first block bounding boxes.

Assertions:

- The side menu is visible while the first block is hovered.
- The side menu becomes hidden 120 pixels outside the editor.
- The side menu remains hidden after a second movement outside the editor and within BlockNote's 250-pixel detection range.

The outside assertion failed on the unmodified client and passed after the implementation.

The BlockNote, Markdown, and Shared Notes regression specs completed with 26 passing Chromium tests.

## Manual Test Cases

| Scenario | Expected result | Result obtained |
|---|---|---|
| Hover a block inside the editor | Side-menu buttons appear for that block | Passed |
| Move 120 px outside the editor at the same Y coordinate | Side menu disappears | Passed |
| Continue moving outside within BlockNote's 250 px range | Side menu remains hidden | Passed |
| Shared Notes pinned in the media area | Existing pin/unpin behavior remains functional | Passed through the existing E2E suite |
| Locked viewer | Viewer remains read-only without a side menu | Passed through the existing E2E suite |
| Markdown import/export and synchronization | Existing behavior remains functional | Passed through the regression suite |
| Drag and drop to the panel boundary | Existing drag behavior remains functional | Passed: dragging `drag source` by the handle to the top boundary moved it from index 5 to index 0 |
| Open drag-handle dropdown, then leave the panel | Frozen menu remains available | Passed: one dropdown remained open outside the panel and closed normally with Escape |
| Mobile/touch viewport | Notes remain usable without mouse-specific behavior | Passed at 390x844 with `hasTouch`: text entry succeeded, no side menu was rendered, and body overflow was 0 px |
| Etherpad meeting | BlockNote-specific code has no effect | Passed: Etherpad accepted text and the client contained zero BlockNote editor elements |

## Evidence

### Before

The original behavior shows the BlockNote side-menu buttons remaining visible while the pointer is outside the editor but near a block at the same vertical position.

- Video (click the preview below to open the full 17s MP4):

  [![Before: side menu visible with the cursor outside the editor](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-08-18/f4d42b13-d93c-4f22-aed2-0db49619d58f/before.gif)](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-08-18/5f2d2458-eec4-4f81-a6e8-fd29c5358ce5/before.mp4)
- Screenshot: [side menu visible with the cursor on the whiteboard](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-08-18/53a9d88a-29ed-4289-92eb-9ac62bcafd91/B_outside_editor_near.png)
- Red E2E log: attached by the automation run (failing assertion at 120px outside the editor)

### After

The updated client shows the buttons while hovering a block and removes them when the pointer moves into the whiteboard area.

- Video (click the preview below to open the full MP4):

  [![After: side menu appears inside the editor and hides outside it](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-08-18/9588561b-fd92-4959-abeb-9b3f1fda4058/after2.gif)](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-08-18/77fd82a9-f56d-4523-9ecd-a220ad3317e1/f536a1bda422dc7283d576828bf797bc.webm)
- Inside-editor screenshot: side menu visible on the hovered block (frame of the MP4 above)
- Symptom 2 before: [H1 side menu 108px overflowing into the next block](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-08-18/4c36be5b-4986-41de-9bc6-2fdfb79500a1/G_h1_sidemenu_overflow.png)
- Green E2E log: attached by the automation run
- Regression log: 26 Chromium tests passing across the BlockNote, Markdown and Shared Notes suites
- Heading-height screenshot after the fix: [H1 side menu 24px, contained in the block](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-08-18/93820b4f-cbca-4d81-bd30-9545777b3a5e/postfix_h1_sidemenu.png)
- Final matrix screenshots: `matrix_drag_drop.png`, `matrix_dropdown_outside.png`, `matrix_mobile_touch.png`, and `matrix_etherpad.png`
- Final matrix measurements: `final-matrix-results.json` and `drag-row-results.json`

The video and screenshots were visually inspected after capture.

### Side-menu height measurements

- Before the specificity fix: H1 menu 108 px, H1 block 84 px, 23.8 px lower overflow.
- After the specificity fix: H1 menu 24 px / block 84 px; H2 menu 24 px / block 63 px; H3 menu 24 px / block 48.3 px. All three menus stayed within their blocks. The H1 measurement was re-taken on the rebased bundle (BlockNote 0.53); the H2/H3 figures come from the pre-rebase bundle.
- Remaining caveat: file, audio, and missing-URL alignment remains unmeasured.

## Risks / Notes

- The workaround should be removed after BlockNote resolves issues 1016 and 351 and BBB upgrades to a version containing the upstream fix.
- The natural-height override addresses the typography mismatch tracked by BlockNote issue 2224 without changing BlockNote's positioning algorithm. H1/H2/H3 were measured on the final bundle; file, audio, and missing-URL alignment remains unmeasured.
- `hideMenuIfNotFrozen()` intentionally preserves an open drag-handle menu when the pointer leaves the panel.
- The listener is mouse-specific and does not introduce pointer movement behavior for touch input.
- The issue was reported against BBB 3.0, while this change targets the issue's Release 4.0 milestone. Cherry-picking `9af1a9f469` onto `v3.0.x-develop` does not apply cleanly: `bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx` has a content conflict. A v3.0 backport can be prepared as a follow-up; no backport PR was created.
- No documentation update is required because the side-menu hover behavior is not documented.

