### PR TITLE
fix(sidebar-navigation): stop ghost scrollbar in the navigation rail

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
@@ -17,6 +17,7 @@ import {
   ComponentsContext,
   FormattingToolbar,
   NestBlockButton,
+  SuggestionMenuController,
   UnnestBlockButton,
   useComponentsContext,
   useCreateBlockNote,
@@ -24,7 +25,7 @@ import {
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { Menu as MantineMenu } from '@mantine/core';
 
-import { Plugin, PluginKey } from '@tiptap/pm/state';
+import { Plugin, PluginKey, Transaction } from '@tiptap/pm/state';
 import { Extension } from '@tiptap/core';
 import { defineMessages, useIntl } from 'react-intl';
 import Styled from './styles';
@@ -84,6 +85,17 @@ const escapeBlurExtension = Extension.create({
     };
   },
 });
+
+const shouldOpenSlashMenu = (transaction: Transaction) => {
+  const { $from } = transaction.selection;
+  if ($from.parent.type.isInGroup('tableContent')) return false;
+
+  const previousCharacter = $from.parent.textBetween(
+    Math.max(0, $from.parentOffset - 1),
+    $from.parentOffset,
+  );
+  return previousCharacter === '' || /\s/.test(previousCharacter);
+};
 
 // TODO: remove this workaround once y-prosemirror's cursor decoration can set `marks: []`
 // (the upstream-correct fix is `marks: []` on the cursor `Decoration.widget` in
@@ -480,6 +492,7 @@ function BlockNoteApp(props: BlockNoteAppProps): React.ReactElement {
         editor={editor}
         theme="light"
         formattingToolbar={!STATIC_FORMATTING_TOOLBAR_ENABLED}
+        slashMenu={false}
         renderEditor={false}
       >
         {STATIC_FORMATTING_TOOLBAR_ENABLED && editable && (
@@ -507,7 +520,12 @@ function BlockNoteApp(props: BlockNoteAppProps): React.ReactElement {
             </div>
           </ToolbarWithAccessibleMenus>
         )}
-        <BlockNoteViewEditor />
+        <BlockNoteViewEditor>
+          <SuggestionMenuController
+            triggerCharacter="/"
+            shouldOpen={shouldOpenSlashMenu}
+          />
+        </BlockNoteViewEditor>
       </BlockNoteView>
       {isImportModalOpen && editable && (
         <MarkdownImportModal

--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/ui-commands/handler.tsx
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/ui-commands/handler.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import PluginChatUiCommandsHandler from './chat/handler';
 import PluginSidekickOptionsContainerUiCommandsHandler from './sidekick-options-container/handler';
+import PluginSidekickAreaUiCommandsHandler from './sidekick-area/handler';
 import PluginPresentationAreaUiCommandsHandler from './presentation/handler';
 import PluginUserStatusUiCommandsHandler from './user-status/handler';
 import PluginConferenceUiCommandsHandler from './conference/handler';
@@ -22,6 +23,7 @@ const PluginUiCommandsHandler = () => (
     <PluginCaptionsUiCommandsHandler />
     <PluginNavBarUiCommandsHandler />
     <PluginSidekickOptionsContainerUiCommandsHandler />
+    <PluginSidekickAreaUiCommandsHandler />
     <PluginPresentationAreaUiCommandsHandler />
     <PluginUserStatusUiCommandsHandler />
     <PluginConferenceUiCommandsHandler />

--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/ui-commands/sidekick-area/handler.tsx
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/ui-commands/sidekick-area/handler.tsx
@@ -1,0 +1,202 @@
+import { useCallback, useEffect } from 'react';
+import {
+  SidekickAreaCorePanelEnum,
+  SidekickAreaPanelEnum,
+} from 'bigbluebutton-html-plugin-sdk/dist/cjs/ui-commands/sidekick-area/panel/enums';
+import {
+  SidekickAreaPanelCommandArguments,
+} from 'bigbluebutton-html-plugin-sdk/dist/cjs/ui-commands/sidekick-area/panel/types';
+import logger from '/imports/startup/client/logger';
+import { layoutDispatch, layoutSelectInput } from '/imports/ui/components/layout/context';
+import { ACTIONS, PANELS } from '/imports/ui/components/layout/enums';
+import { Input } from '/imports/ui/components/layout/layoutTypes';
+import { useIsMultiFunctionalModeEnabled } from '/imports/ui/services/features';
+
+// A plugin can dispatch the raw event, so the enum alone is not a boundary.
+const ALLOWED_CORE_PANELS: string[] = Object.values(SidekickAreaCorePanelEnum);
+
+// The only core panels kept in registeredApps, whose registration already encodes the
+// user's role and the feature flag.
+const REGISTRY_BACKED_CORE_PANELS: string[] = [
+  PANELS.POLL,
+  PANELS.TIMER,
+  PANELS.BREAKOUT,
+];
+
+const PluginSidekickAreaUiCommandsHandler = () => {
+  const CHAT_CONFIG = window.meetingClientSettings.public.chat;
+  const PUBLIC_GROUP_CHAT_ID = CHAT_CONFIG.public_group_id;
+  const layoutContextDispatch = layoutDispatch();
+  const { registeredApps } = layoutSelectInput((i: Input) => i.sidebarNavigation);
+  const {
+    sidebarContentPanel,
+    isOpen: isSidebarContentOpen,
+  } = layoutSelectInput((i: Input) => i.sidebarContent);
+  const {
+    sidebarContentPanel: sidebarContentPanelAuxiliary,
+    isOpen: isAuxiliaryOpen,
+  } = layoutSelectInput((i: Input) => i.sidebarContentAuxiliary);
+  const isMultiFunctionalModeEnabled = useIsMultiFunctionalModeEnabled();
+
+  const resolvePanel = useCallback((
+    { id }: SidekickAreaPanelCommandArguments,
+  ): string | null => {
+    if (!id) return null;
+
+    if (ALLOWED_CORE_PANELS.includes(id)) {
+      if (REGISTRY_BACKED_CORE_PANELS.includes(id)) {
+        if (registeredApps?.[id]) {
+          return id;
+        }
+        logger.info({
+          logCode: 'plugin_core_panel_unavailable',
+          extraInfo: { panel: id },
+        }, 'Plugin asked for a core panel unavailable to this user. Ignored.');
+        return null;
+      }
+      return id;
+    }
+
+    const genericContentPanel = PANELS.GENERIC_CONTENT_SIDEKICK + id;
+
+    // An unregistered panel would open the sidebar content area empty.
+    if (!registeredApps?.[genericContentPanel]) {
+      logger.warn({
+        logCode: 'plugin_sidekick_panel_unknown_id',
+        extraInfo: { id },
+      }, 'Plugin asked for a sidekick panel that is not registered');
+      return null;
+    }
+    return genericContentPanel;
+  }, [registeredApps]);
+
+  const handlePanelOpen = useCallback((
+    event: CustomEvent<SidekickAreaPanelCommandArguments>,
+  ) => {
+    const request = event.detail;
+
+    if (!request?.id) {
+      logger.info({
+        logCode: 'plugin_sidekick_panel_open_without_target',
+      }, 'Plugin tried to open a sidekick panel without naming one. Ignored.');
+      return;
+    }
+
+    const panel = resolvePanel(request);
+    if (!panel) return;
+
+    // Asking for a panel already on display while the auxiliary sidebar is open would
+    // copy it there, showing the same content twice and dropping what was in it.
+    const isDisplayedInSidebarContent = isSidebarContentOpen && sidebarContentPanel === panel;
+    const isDisplayedInAuxiliary = isMultiFunctionalModeEnabled
+      && isAuxiliaryOpen
+      && sidebarContentPanelAuxiliary === panel;
+    if (isDisplayedInSidebarContent || isDisplayedInAuxiliary) return;
+
+    layoutContextDispatch({
+      type: ACTIONS.SET_SIDEBAR_CONTENT_IS_OPEN,
+      value: true,
+    });
+    if (panel === PANELS.CHAT) {
+      layoutContextDispatch({
+        type: ACTIONS.SET_ID_CHAT_OPEN,
+        value: PUBLIC_GROUP_CHAT_ID,
+      });
+    }
+    layoutContextDispatch({
+      type: ACTIONS.SET_SIDEBAR_CONTENT_PANEL,
+      value: panel,
+    });
+  }, [
+    resolvePanel,
+    layoutContextDispatch,
+    isSidebarContentOpen,
+    sidebarContentPanel,
+    isMultiFunctionalModeEnabled,
+    isAuxiliaryOpen,
+    sidebarContentPanelAuxiliary,
+  ]);
+
+  const handlePanelClose = useCallback((
+    event: CustomEvent<SidekickAreaPanelCommandArguments>,
+  ) => {
+    const request = event.detail;
+    const namesAPanel = Boolean(request?.id);
+    let panel: string | null = null;
+
+    if (namesAPanel) {
+      panel = resolvePanel(request);
+      if (!panel) return;
+    }
+
+    // The named panel may be in the auxiliary sidebar rather than the primary one.
+    const isInAuxiliaryPanel = isMultiFunctionalModeEnabled
+      && isAuxiliaryOpen
+      && panel !== null
+      && sidebarContentPanelAuxiliary === panel;
+
+    // Only close a panel that is on display, so a plugin does not close one it does
+    // not own. Naming none closes the sidekick area.
+    if (namesAPanel && panel !== sidebarContentPanel && !isInAuxiliaryPanel) return;
+
+    if (panel === PANELS.CHAT) {
+      layoutContextDispatch({
+        type: ACTIONS.SET_ID_CHAT_OPEN,
+        value: undefined,
+      });
+    }
+
+    if (isInAuxiliaryPanel) {
+      // As in usePanelClose: the auxiliary sidebar keeps its panel while closed so the
+      // core can restore it, so only isOpen flips.
+      layoutContextDispatch({
+        type: ACTIONS.SET_SIDEBAR_CONTENT_AUXILIARY_IS_OPEN,
+        value: false,
+      });
+      return;
+    }
+
+    // Closing the primary sidebar closes the auxiliary with it, so this must run before
+    // PANELS.NONE, which would otherwise be routed into the auxiliary.
+    layoutContextDispatch({
+      type: ACTIONS.SET_SIDEBAR_CONTENT_IS_OPEN,
+      value: false,
+    });
+    layoutContextDispatch({
+      type: ACTIONS.SET_SIDEBAR_CONTENT_PANEL,
+      value: PANELS.NONE,
+    });
+  }, [
+    resolvePanel,
+    layoutContextDispatch,
+    sidebarContentPanel,
+    isMultiFunctionalModeEnabled,
+    isAuxiliaryOpen,
+    sidebarContentPanelAuxiliary,
+  ]);
+
+  useEffect(() => {
+    window.addEventListener(
+      SidekickAreaPanelEnum.OPEN,
+      handlePanelOpen as EventListener,
+    );
+    window.addEventListener(
+      SidekickAreaPanelEnum.CLOSE,
+      handlePanelClose as EventListener,
+    );
+
+    return () => {
+      window.removeEventListener(
+        SidekickAreaPanelEnum.OPEN,
+        handlePanelOpen as EventListener,
+      );
+      window.removeEventListener(
+        SidekickAreaPanelEnum.CLOSE,
+        handlePanelClose as EventListener,
+      );
+    };
+  }, [handlePanelOpen, handlePanelClose]);
+  return null;
+};
+
+export default PluginSidekickAreaUiCommandsHandler;

--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/ui-commands/sidekick-area/handler.tsx
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/ui-commands/sidekick-area/handler.tsx
@@ -10,7 +10,11 @@ import logger from '/imports/startup/client/logger';
 import { layoutDispatch, layoutSelectInput } from '/imports/ui/components/layout/context';
 import { ACTIONS, PANELS } from '/imports/ui/components/layout/enums';
 import { Input } from '/imports/ui/components/layout/layoutTypes';
-import { useIsMultiFunctionalModeEnabled } from '/imports/ui/services/features';
+import {
+  useIsChatEnabled,
+  useIsMultiFunctionalModeEnabled,
+  useIsSharedNotesEnabled,
+} from '/imports/ui/services/features';
 
 // A plugin can dispatch the raw event, so the enum alone is not a boundary.
 const ALLOWED_CORE_PANELS: string[] = Object.values(SidekickAreaCorePanelEnum);
@@ -36,7 +40,21 @@ const PluginSidekickAreaUiCommandsHandler = () => {
     sidebarContentPanel: sidebarContentPanelAuxiliary,
     isOpen: isAuxiliaryOpen,
   } = layoutSelectInput((i: Input) => i.sidebarContentAuxiliary);
+  const isSharedNotesPinned = layoutSelectInput((i: Input) => i.sharedNotes?.isPinned ?? false);
   const isMultiFunctionalModeEnabled = useIsMultiFunctionalModeEnabled();
+  const isChatEnabled = useIsChatEnabled();
+  const isSharedNotesEnabled = useIsSharedNotesEnabled();
+
+  const isCorePanelAvailable = useCallback((id: string): boolean => {
+    // No separate isEnabled check needed here: a disabled feature simply never registers.
+    if (REGISTRY_BACKED_CORE_PANELS.includes(id)) {
+      return Boolean(registeredApps?.[id]);
+    }
+    if (id === PANELS.CHAT) return isChatEnabled;
+    // Pinned notes render in the presentation area, so opening the panel would show it empty.
+    if (id === PANELS.SHARED_NOTES) return isSharedNotesEnabled && !isSharedNotesPinned;
+    return true;
+  }, [registeredApps, isChatEnabled, isSharedNotesEnabled, isSharedNotesPinned]);
 
   const resolvePanel = useCallback((
     { id }: SidekickAreaPanelCommandArguments,
@@ -44,10 +62,7 @@ const PluginSidekickAreaUiCommandsHandler = () => {
     if (!id) return null;
 
     if (ALLOWED_CORE_PANELS.includes(id)) {
-      if (REGISTRY_BACKED_CORE_PANELS.includes(id)) {
-        if (registeredApps?.[id]) {
-          return id;
-        }
+      if (!isCorePanelAvailable(id)) {
         logger.info({
           logCode: 'plugin_core_panel_unavailable',
           extraInfo: { panel: id },
@@ -68,7 +83,7 @@ const PluginSidekickAreaUiCommandsHandler = () => {
       return null;
     }
     return genericContentPanel;
-  }, [registeredApps]);
+  }, [registeredApps, isCorePanelAvailable]);
 
   const handlePanelOpen = useCallback((
     event: CustomEvent<SidekickAreaPanelCommandArguments>,

--- a/bigbluebutton-html5/imports/ui/components/sidebar-navigation/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/sidebar-navigation/component.tsx
@@ -203,6 +203,7 @@ const SidebarNavigation = ({
         )}
         <Styled.NavigationSidebarListItemsContainer
           ref={scrollRef}
+          data-test="sidebarNavigationScrollbox"
           isMobile={isMobile}
           noVirtualScrollboxBackground={noVirtualScrollboxBackground}
           isExpanded={isExpanded}

--- a/bigbluebutton-html5/imports/ui/components/sidebar-navigation/sidebar-navigation-button/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/sidebar-navigation/sidebar-navigation-button/component.tsx
@@ -2,9 +2,11 @@
 import React, { useCallback, memo } from 'react';
 import KEYS from '/imports/utils/keys';
 import resolveIcon from '/imports/ui/components/plugins/plugin-icon/utils';
-import { layoutDispatch, layoutSelectInput } from '/imports/ui/components/layout/context';
-import { Input } from '/imports/ui/components/layout/layoutTypes';
-import { ACTIONS, PANELS } from '/imports/ui/components/layout/enums';
+import { layoutDispatch, layoutSelect, layoutSelectInput } from '/imports/ui/components/layout/context';
+import { Input, Layout } from '/imports/ui/components/layout/layoutTypes';
+import {
+  ACTIONS, DEVICE_TYPE, PANELS,
+} from '/imports/ui/components/layout/enums';
 import TooltipContainer from '/imports/ui/components/common/tooltip/container';
 import { SidebarNavigationButtonProps } from './types';
 import Styled from './styles';
@@ -29,6 +31,11 @@ const SidebarNavigationButton: React.FC<SidebarNavigationButtonProps> = ({
   ariaDescribedBy,
 }) => {
   const layoutContextDispatch = layoutDispatch();
+  // Same source of truth as the rail scrollbox gutter (deviceType === MOBILE, i.e.
+  // width <= 599px), so the icon width and the gutter switch at the same threshold
+  // and the 600-640px band no longer dips the icons to the mobile size (issue 25564).
+  const deviceType = layoutSelect((i: Layout) => i.deviceType);
+  const isMobile = deviceType === DEVICE_TYPE.MOBILE;
   const sidebarContentAuxiliaryInput = layoutSelectInput((i: Input) => i.sidebarContentAuxiliary);
   const {
     sidebarContentPanel: sidebarContentPanelAuxiliary,
@@ -107,6 +114,7 @@ const SidebarNavigationButton: React.FC<SidebarNavigationButtonProps> = ({
         $hasPrivateNotification={hasPrivateNotification}
         $disabled={isDisabled}
         $locked={isLocked}
+        $isMobile={isMobile}
       >
         {resolveIcon(iconName)}
         {children}

--- a/bigbluebutton-html5/imports/ui/components/sidebar-navigation/sidebar-navigation-button/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/sidebar-navigation/sidebar-navigation-button/styles.ts
@@ -3,6 +3,7 @@ import {
   borderSize,
   borderSizeSmall,
   navigationSidebarListItemsWidth,
+  navigationSidebarListItemsWidthDesktop,
   navigationSidebarIconSize,
   navigationSidebarIconSizeSmallHeight,
   navigationSidebarNotificationBadgeSize,
@@ -33,9 +34,17 @@ export const ListItem = styled.div<ListItemProps>`
   text-decoration: none;
   color: ${colorGrayIcons};
   cursor: pointer;
-  width: ${navigationSidebarListItemsWidth};
+  /* The fixed desktop size is in rem, so it follows the user font-size setting.
+     Cap it at 100% (the scrollbox content box, which is the rail minus the
+     reserved scrollbar gutter) so a larger font scales the icon up but never
+     overflows the content box. */
+  width: min(${navigationSidebarListItemsWidthDesktop}, 100%);
   aspect-ratio: 1 / 1;
   border-radius: 50%;
+
+  ${({ $isMobile }: ListItemProps) => $isMobile && `
+    width: ${navigationSidebarListItemsWidth};
+  `}
 
   > i {
     font-size: ${navigationSidebarIconSize};

--- a/bigbluebutton-html5/imports/ui/components/sidebar-navigation/sidebar-navigation-button/types.ts
+++ b/bigbluebutton-html5/imports/ui/components/sidebar-navigation/sidebar-navigation-button/types.ts
@@ -27,4 +27,5 @@ export interface ListItemProps {
   $hasPrivateNotification?: boolean;
   $disabled?: boolean;
   $locked?: boolean;
+  $isMobile?: boolean;
 }

--- a/bigbluebutton-html5/imports/ui/components/sidebar-navigation/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/sidebar-navigation/styles.ts
@@ -115,6 +115,11 @@ const NavigationSidebarListItemsContainer = styled(ScrollboxVertical)<{
     gap: ${navigationSidebarListItemsContainerGapSmallHeight};
   }
 
+  ${({ isMobile }) => !isMobile && `
+    scrollbar-gutter: stable both-edges;
+    scrollbar-width: thin;
+  `}
+
   ${({ isExpanded }) => (isExpanded ? `
     max-height: 100%;
     opacity: 1;

--- a/bigbluebutton-html5/imports/ui/stylesheets/styled-components/general.js
+++ b/bigbluebutton-html5/imports/ui/stylesheets/styled-components/general.js
@@ -53,6 +53,11 @@ const navigationSidebarListItemsContainerGapSmallHeight = 'calc(9rem / 14)';
 const navigationSidebarListItemsGap = 'calc(12rem / 14)';
 const navigationSidebarListItemsGapSmallHeight = 'calc(6rem / 14)';
 const navigationSidebarListItemsWidth = '65%';
+// Fixed desktop size for the rail icon buttons. On desktop the rail width is
+// constant (60px), so a fixed size decouples the icons from the scrollbar width
+// and stops the classic scrollbar from shrinking the very icons that caused it
+// (issue 25564). Mobile keeps the responsive percentage above.
+const navigationSidebarListItemsWidthDesktop = 'calc(39rem / 14)';
 const navigationSidebarIconSize = 'calc(18rem / 14)';
 const navigationSidebarIconSizeSmallHeight = '1rem';
 const navigationSidebarNotificationBadgeSize = '14px';
@@ -172,6 +177,7 @@ export {
   navigationSidebarListItemsGap,
   navigationSidebarListItemsGapSmallHeight,
   navigationSidebarListItemsWidth,
+  navigationSidebarListItemsWidthDesktop,
   navigationSidebarIconSize,
   navigationSidebarIconSizeSmallHeight,
   navigationSidebarNotificationBadgeSize,

--- a/bigbluebutton-html5/package-lock.json
+++ b/bigbluebutton-html5/package-lock.json
@@ -36,7 +36,7 @@
         "@types/react": "^18.2.18",
         "autoprefixer": "^10.4.4",
         "babel-runtime": "~6.26.0",
-        "bigbluebutton-html-plugin-sdk": "0.1.24",
+        "bigbluebutton-html-plugin-sdk": "0.1.26",
         "bowser": "^2.12.0",
         "browser-bunyan": "^1.8.0",
         "classnames": "^2.2.6",
@@ -7239,9 +7239,9 @@
       }
     },
     "node_modules/bigbluebutton-html-plugin-sdk": {
-      "version": "0.1.24",
-      "resolved": "https://registry.npmjs.org/bigbluebutton-html-plugin-sdk/-/bigbluebutton-html-plugin-sdk-0.1.24.tgz",
-      "integrity": "sha512-TmFEKfZnE8AvYQSvVeV7ZjEKO9HjfhZa6TghS8Ltn6bQKXlebdWL5efJ7L/qh8f5SvORB/vToRQwx4TunA+wsQ==",
+      "version": "0.1.26",
+      "resolved": "https://registry.npmjs.org/bigbluebutton-html-plugin-sdk/-/bigbluebutton-html-plugin-sdk-0.1.26.tgz",
+      "integrity": "sha512-EANOpZiIPsm69npnQf20r6ymhjyQAr8p3zjHyyPHwm7avFtDUt/5kkVBzDBq7emHr4WSYCDrVOxphqCywxC+eg==",
       "license": "LGPL-3.0",
       "dependencies": {
         "@apollo/client": "^3.8.7",

--- a/bigbluebutton-html5/package.json
+++ b/bigbluebutton-html5/package.json
@@ -79,7 +79,7 @@
     "@types/react": "^18.2.18",
     "autoprefixer": "^10.4.4",
     "babel-runtime": "~6.26.0",
-    "bigbluebutton-html-plugin-sdk": "0.1.24",
+    "bigbluebutton-html-plugin-sdk": "0.1.26",
     "bowser": "^2.12.0",
     "browser-bunyan": "^1.8.0",
     "classnames": "^2.2.6",

--- a/bigbluebutton-tests/playwright/core/elements.ts
+++ b/bigbluebutton-tests/playwright/core/elements.ts
@@ -52,6 +52,7 @@ export const elements = {
   closePopup: 'button[data-test="closePopup"]',
   restoreWelcomeMessages: 'li[data-test="restoreWelcomeMessages"]',
   navigationSidebarContainer: 'div[data-test="navigationSidebarContainer"]',
+  sidebarNavigationScrollbox: 'div[data-test="sidebarNavigationScrollbox"]',
   appsGallerySidebarButton: 'div[data-test="appsGallerySidebarButton"]',
 
   // Accesskey

--- a/bigbluebutton-tests/playwright/layouts/sidebarNavigation.spec.ts
+++ b/bigbluebutton-tests/playwright/layouts/sidebarNavigation.spec.ts
@@ -1,0 +1,61 @@
+import { initializePages, linkIssue } from '../core/helpers';
+import { test } from '../core/setup/fixtures';
+import { SidebarNavigation } from './sidebarNavigation';
+
+test.describe.parallel('Sidebar navigation rail - scrollbar', { tag: '@ci' }, () => {
+  // Spec A: the ghost scrollbar. Needs real (space-consuming) scrollbars, so it
+  // runs on an own browser without --hide-scrollbars (still headless in CI).
+  test('Icon buttons keep their size when the rail enters the ghost-scrollbar band', async ({
+    browser,
+    context,
+  }, testInfo) => {
+    linkIssue(25564);
+    const nav = new SidebarNavigation(browser, context);
+    try {
+      await nav.initModPageWithVisibleScrollbars(testInfo);
+      await nav.assertGhostScrollbarAbsent();
+    } finally {
+      await nav.closeVisibleScrollbarsPage();
+    }
+  });
+
+  // Spec C: dynamic viewport resizes, the real-world trigger of the issue.
+  test('Rail stays correct across viewport resizes (bar only on real overflow)', async ({
+    browser,
+    context,
+  }, testInfo) => {
+    linkIssue(25564);
+    const nav = new SidebarNavigation(browser, context);
+    try {
+      await nav.initModPageWithVisibleScrollbars(testInfo);
+      await nav.assertResizeInvariant();
+    } finally {
+      await nav.closeVisibleScrollbarsPage();
+    }
+  });
+
+  // Spec B: CI-safe height-budget guard on the default (scrollbars-hidden) browser.
+  test('Sidebar navigation scrolls only when the content really overflows', async ({ browser, context }, testInfo) => {
+    linkIssue(25564);
+    const nav = new SidebarNavigation(browser, context);
+    await initializePages(nav, browser, { testInfo });
+    await nav.assertOverflowIsHonest();
+  });
+
+  // Spec D: the icon size follows the user font-size setting but never overflows the
+  // scrollbox content box. Needs real scrollbars, so it runs on the same own browser
+  // as Specs A and C: with the gutter hidden the content box bound is invisible.
+  test('Rail icons follow the user font size and stay within the rail content box', async ({
+    browser,
+    context,
+  }, testInfo) => {
+    linkIssue(25564);
+    const nav = new SidebarNavigation(browser, context);
+    try {
+      await nav.initModPageWithVisibleScrollbars(testInfo);
+      await nav.assertFontSizeScaling();
+    } finally {
+      await nav.closeVisibleScrollbarsPage();
+    }
+  });
+});

--- a/bigbluebutton-tests/playwright/layouts/sidebarNavigation.ts
+++ b/bigbluebutton-tests/playwright/layouts/sidebarNavigation.ts
@@ -1,0 +1,224 @@
+import { Browser, BrowserContext, chromium, expect, TestInfo } from '@playwright/test';
+
+import { elements as e } from '../core/elements';
+import { Page } from '../core/page';
+import { MultiUsers } from '../user/multiusers';
+
+// Viewports used to exercise the navigation rail (icon column) at 1280px wide.
+// REGIME_A is tall enough that every icon fits with no scroll. GHOST_BAND is the
+// height range where, before the fix, the classic 5px scrollbar reserved width
+// with zero real overflow and shrank the icons that caused it (issue 25564).
+// OVERFLOW is genuinely too short, so a real scrollbar is expected there.
+const REGIME_A = { width: 1280, height: 616 };
+const GHOST_BAND = { width: 1280, height: 550 };
+const OVERFLOW = { width: 1280, height: 460 };
+
+interface RailMetrics {
+  offsetWidth: number;
+  clientWidth: number;
+  scrollHeight: number;
+  clientHeight: number;
+  buttonCount: number;
+  buttonWidth: number | null;
+  lastButtonReachable: boolean;
+}
+
+// Reads the geometry of the rail scrollbox and of its circular icon buttons.
+async function measureRail(page: Page): Promise<RailMetrics> {
+  return page.page.evaluate((selector) => {
+    const scrollbox = document.querySelector(selector) as HTMLElement;
+    // The rail icons are the only circular, square-aspect elements inside the scrollbox.
+    const buttons = Array.from(scrollbox.querySelectorAll('div')).filter((el) => {
+      const style = getComputedStyle(el);
+      return style.borderRadius === '50%' && style.aspectRatio === '1 / 1';
+    });
+    const first = buttons[0] as HTMLElement | undefined;
+    const last = buttons[buttons.length - 1] as HTMLElement | undefined;
+    // Scroll to the bottom and check the last icon is inside the viewport (regime C).
+    scrollbox.scrollTop = scrollbox.scrollHeight;
+    let lastButtonReachable = false;
+    if (last) {
+      const boxRect = scrollbox.getBoundingClientRect();
+      const lastRect = last.getBoundingClientRect();
+      lastButtonReachable = lastRect.bottom <= boxRect.bottom + 1 && lastRect.top >= boxRect.top - 1;
+    }
+    scrollbox.scrollTop = 0;
+    return {
+      offsetWidth: scrollbox.offsetWidth,
+      clientWidth: scrollbox.clientWidth,
+      scrollHeight: scrollbox.scrollHeight,
+      clientHeight: scrollbox.clientHeight,
+      buttonCount: buttons.length,
+      buttonWidth: first ? Number(first.getBoundingClientRect().width.toFixed(2)) : null,
+      lastButtonReachable,
+    };
+  }, e.sidebarNavigationScrollbox);
+}
+
+async function measureAt(page: Page, viewport: { width: number; height: number }): Promise<RailMetrics> {
+  await page.setHeightWidthViewPortSize(viewport);
+  // Let the layout engine and the rail ResizeObserver settle after the resize.
+  await page.page.waitForTimeout(600);
+  return measureRail(page);
+}
+
+export class SidebarNavigation extends MultiUsers {
+  private scrollbarBrowser?: Browser;
+
+  private scrollbarContext?: BrowserContext;
+
+  // The ghost scrollbar only forms with classic (space-consuming) scrollbars.
+  // Playwright launches Chromium with --hide-scrollbars by default, which paints
+  // zero-width scrollbars and hides the bug entirely. This moderator page runs on
+  // an own browser with that flag removed, so the rail behaves like a real desktop
+  // Chrome. It still runs headless in CI (no @only-headed needed).
+  async initModPageWithVisibleScrollbars(testInfo?: TestInfo): Promise<void> {
+    this.scrollbarBrowser = await chromium.launch({
+      headless: true,
+      ignoreDefaultArgs: ['--hide-scrollbars'],
+    });
+    this.scrollbarContext = await this.scrollbarBrowser.newContext();
+    const page = await this.scrollbarContext.newPage();
+    this.modPage = new Page(this.scrollbarBrowser, page, testInfo ?? null);
+    await this.modPage.setHeightWidthViewPortSize(REGIME_A);
+    await this.modPage.init(true, { fullName: 'Moderator', testInfo });
+    await this.modPage.hasElement(e.sidebarNavigationScrollbox, 'the sidebar navigation rail should be displayed');
+  }
+
+  async closeVisibleScrollbarsPage(): Promise<void> {
+    await this.scrollbarContext?.close();
+    await this.scrollbarBrowser?.close();
+  }
+
+  // Spec A - the ghost scrollbar itself. With real (space-consuming) scrollbars,
+  // the icon buttons must keep the same size at the ghost-band height as in the
+  // tall regime. Before the fix they shrink (39px -> 35.75px) because the bar
+  // steals width, which is the feedback loop that keeps a zero-overflow bar alive.
+  async assertGhostScrollbarAbsent(): Promise<void> {
+    const tall = await measureAt(this.modPage, REGIME_A);
+    expect(tall.buttonWidth, 'a reference icon size should be measured in the tall regime').not.toBeNull();
+
+    const band = await measureAt(this.modPage, GHOST_BAND);
+    expect(
+      band.buttonWidth,
+      'icon buttons must not shrink when the rail height enters the old ghost-scrollbar band',
+    ).toBe(tall.buttonWidth);
+    // Honest bar: if the content fits, there is no scroll; if it does not, the bar
+    // is backed by real overflow. Either way a zero-overflow reserved bar is gone.
+    if (band.scrollHeight <= band.clientHeight) {
+      expect(band.lastButtonReachable, 'every icon should be visible when the content fits').toBeTruthy();
+    } else {
+      expect(band.lastButtonReachable, 'the last icon should be reachable by scrolling when it overflows').toBeTruthy();
+    }
+  }
+
+  // Spec C - dynamic viewport resizes (the real field trigger). The icon size must
+  // stay constant across the whole critical range, a real scrollbar must appear
+  // only on genuine overflow, and resizing back to the tall regime must leave no
+  // residual scrollbar.
+  async assertResizeInvariant(): Promise<void> {
+    const base = await measureAt(this.modPage, REGIME_A);
+    const reference = base.buttonWidth;
+
+    for (const height of [590, 560, 550, 520, 490, 460]) {
+      // eslint-disable-next-line no-await-in-loop
+      const metrics = await measureAt(this.modPage, { width: 1280, height });
+      expect(metrics.buttonWidth, `icon size must stay constant at 1280x${height}`).toBe(reference);
+    }
+
+    const overflow = await measureAt(this.modPage, OVERFLOW);
+    expect(overflow.scrollHeight, 'the content should really overflow at a very short height').toBeGreaterThan(
+      overflow.clientHeight,
+    );
+    expect(
+      overflow.lastButtonReachable,
+      'the last icon should be reachable by scrolling on real overflow',
+    ).toBeTruthy();
+
+    const backToTall = await measureAt(this.modPage, REGIME_A);
+    expect(
+      backToTall.scrollHeight,
+      'no overflow should remain after resizing back to the tall regime',
+    ).toBeLessThanOrEqual(backToTall.clientHeight);
+    expect(backToTall.buttonWidth, 'icon size must return to the reference size').toBe(reference);
+  }
+
+  // Spec B - CI-safe invariant guard on the default (scrollbars-hidden) browser.
+  // It does not see the ghost bar, but it guards the height budget: the content
+  // fits in the tall regime and a real scroll reaches the last icon when short.
+  async assertOverflowIsHonest(): Promise<void> {
+    const tall = await measureAt(this.modPage, REGIME_A);
+    expect(tall.scrollHeight, 'the rail content should fit without scroll in the tall regime').toBeLessThanOrEqual(
+      tall.clientHeight,
+    );
+
+    const overflow = await measureAt(this.modPage, OVERFLOW);
+    expect(overflow.scrollHeight, 'the rail content should overflow at a very short height').toBeGreaterThan(
+      overflow.clientHeight,
+    );
+    expect(
+      overflow.lastButtonReachable,
+      'the last icon should be reachable by scrolling when it overflows',
+    ).toBeTruthy();
+  }
+
+  // Measures the rail at one user font-size setting. BBB applies the setting to the
+  // html root element (settings/submenus/application, 12-20px), and the layout
+  // observer only rewrites the root font size on a viewport resize, so the value
+  // survives a plain measurement here. Restored before returning.
+  private measureAtFontSize(fontSize: string): Promise<{
+    buttonWidth: number | null;
+    clientWidth: number;
+    scrollWidth: number;
+  }> {
+    return this.modPage.page.evaluate(
+      ([selector, size]) => {
+        const html = document.getElementsByTagName('html')[0];
+        const previousFontSize = html.style.fontSize;
+        html.style.fontSize = size;
+        const scrollbox = document.querySelector(selector) as HTMLElement;
+        const button = Array.from(scrollbox.querySelectorAll('div')).find((el) => {
+          const style = getComputedStyle(el);
+          return style.borderRadius === '50%' && style.aspectRatio === '1 / 1';
+        }) as HTMLElement | undefined;
+        const result = {
+          buttonWidth: button ? Number(button.getBoundingClientRect().width.toFixed(2)) : null,
+          clientWidth: scrollbox.clientWidth,
+          scrollWidth: scrollbox.scrollWidth,
+        };
+        html.style.fontSize = previousFontSize;
+        return result;
+      },
+      [e.sidebarNavigationScrollbox, fontSize],
+    );
+  }
+
+  // Spec D - locks in the font-size coupling and its bound. The desktop icon size is
+  // min(calc(39rem / 14), 100%), so it follows the user font-size setting up to the
+  // scrollbox content box (the rail minus the reserved scrollbar gutter). It must keep
+  // tracking the setting, and at the largest setting it must stay inside that content
+  // box, so the rail never overflows horizontally (issue 25564). This needs real
+  // (space-consuming) scrollbars: with --hide-scrollbars the gutter is zero and the
+  // content box is the whole rail, so the bound being guarded here cannot be observed.
+  async assertFontSizeScaling(): Promise<void> {
+    const base = await measureAt(this.modPage, REGIME_A);
+    const reference = base.buttonWidth;
+    expect(reference, 'a reference icon size should be measured at the default font size').not.toBeNull();
+
+    // Below the cap the icon still tracks the setting, which is the rem coupling.
+    const smallest = await this.measureAtFontSize('12px');
+    expect(
+      smallest.buttonWidth as number,
+      'the icon size should follow the user font size at the smallest setting',
+    ).toBeLessThan(reference as number);
+
+    const largest = await this.measureAtFontSize('20px');
+    expect(
+      largest.buttonWidth as number,
+      'the icon must stay within the scrollbox content box at the largest font size',
+    ).toBeLessThanOrEqual(largest.clientWidth);
+    expect(largest.scrollWidth, 'the rail must not overflow horizontally at the largest font size').toBeLessThanOrEqual(
+      largest.clientWidth,
+    );
+  }
+}

--- a/bigbluebutton-tests/playwright/sharednotes/blocknote/sharednotes.spec.ts
+++ b/bigbluebutton-tests/playwright/sharednotes/blocknote/sharednotes.spec.ts
@@ -17,6 +17,13 @@ test.describe.parallel('Shared Notes - BlockNote', { tag: '@ci' }, () => {
     await sharedNotes.typeInSharedNotes();
   });
 
+  test('Type fractions without opening the slash menu', async ({ browser, context }, testInfo) => {
+    linkIssue(25577);
+    const sharedNotes = new BlockNoteSharedNotes(browser, context);
+    await initializePages(sharedNotes, browser, { isMultiUser: true, createParameter: CREATE_PARAMETER, testInfo });
+    await sharedNotes.typeFractionsWithoutOpeningSlashMenu();
+  });
+
   test('Format text in shared notes', async ({ browser, context }, testInfo) => {
     const sharedNotes = new BlockNoteSharedNotes(browser, context);
     await initializePages(sharedNotes, browser, { isMultiUser: true, createParameter: CREATE_PARAMETER, testInfo });

--- a/bigbluebutton-tests/playwright/sharednotes/blocknote/sharednotes.ts
+++ b/bigbluebutton-tests/playwright/sharednotes/blocknote/sharednotes.ts
@@ -55,6 +55,39 @@ export class BlockNoteSharedNotes extends MultiUsers {
     await this.modPage.wasRemoved(e.hideNotesLabel, 'should not display the hide notes label');
   }
 
+  async typeFractionsWithoutOpeningSlashMenu() {
+    const { sharedNotesEnabled } = this.modPage.settings || {};
+
+    if (!sharedNotesEnabled) {
+      await this.modPage.hasElement(e.messagesSidebarButton, 'should display the public chat button');
+      await this.modPage.wasRemoved(e.sharedNotesSidebarButton, 'should not display the shared notes button');
+      return;
+    }
+
+    await startSharedNotesBlockNote(this.modPage);
+    const editorLocator = getBlockNoteEditorLocator(this.modPage);
+    const equation = '1/4 + 1/4 = 1/2';
+    await editorLocator.click();
+    await editorLocator.pressSequentially(equation);
+
+    await expect(
+      this.modPage.page.locator(e.blockNoteSlashMenuItem),
+      'a slash inside a fraction should not open the slash menu',
+    ).toHaveCount(0);
+
+    await editorLocator.press('Enter');
+    await expect(editorLocator, 'pressing Enter should keep the complete equation').toContainText(equation);
+
+    await editorLocator.pressSequentially('/');
+    await expect(
+      this.modPage.page.locator(e.blockNoteSlashMenuItem).first(),
+      'a slash at the start of a block should open the slash menu',
+    ).toBeVisible({ timeout: ELEMENT_WAIT_TIME });
+
+    await this.modPage.waitAndClick(e.hideNotesLabel);
+    await this.modPage.wasRemoved(e.hideNotesLabel, 'should not display the hide notes label');
+  }
+
   async formatTextInSharedNotes() {
     const { sharedNotesEnabled } = this.modPage.settings || {};
 

--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -622,4 +622,4 @@ pluginManifestCacheRefreshIntervalMinutes=60
 # List the parameters without including the 'userdata-' prefix
 getJoinUrlUserdataBlocklist=bbb_record_permission,bbb_record_video,bbb_fullaudio_bridge,bbb_transparent_listen_only,bbb_multi_user_pen_only,bbb_presenter_tools,bbb_multi_user_tools
 
-html5PluginSdkVersion=0.1.24
+html5PluginSdkVersion=0.1.26


### PR DESCRIPTION
## Summary

On desktop, the navigation rail (the left icon column) showed a full-height scrollbar even when every icon was visible and nothing overflowed. This is the bug reported in bigbluebutton/bigbluebutton#25564, observed on HD (1280x720) screens.

Closes bigbluebutton/bigbluebutton#25564

Expected behavior: the scrollbar should only appear when the rail content actually overflows.

User impact: a permanent grey scrollbar cluttered the rail on common desktop window sizes, and the icons were subtly smaller than intended because the bar stole width from them.

This PR breaks the layout feedback loop that produced the bar, so the rail icons keep a stable size and a scrollbar appears only on real overflow. On tall windows the rail is visually identical to before, down to the icon size and centres; the only rendered difference is that the two group separator lines are 5px narrower.

## Root Cause

The rail icons size themselves from the rail width: `width: 65%` + `aspect-ratio: 1 / 1`, so each icon's height is derived from the rail's width, never from the available height. The rail scrollbox is a `ScrollboxVertical` with a classic, space-consuming `::-webkit-scrollbar` (5px, track always painted).

That combination creates a stable oscillation:

1. The natural icon stack (39px icons) slightly exceeds the available height, so the scrollbar appears.
2. The classic scrollbar steals 5px of width, shrinking the icons to 35.75px (65% of 55px).
3. The now-smaller stack fits, so there is no real overflow.
4. The browser keeps the (now empty) scrollbar: a full-height bar whose thumb fills the track, over content with zero overflow that cannot be scrolled. That is exactly the reported symptom.

The two pre-existing conditions that made this possible:

- `3666850e0a` (2024-11, rail introduction): icon size coupled to the rail width (`65%` + `aspect-ratio: 1/1`).
- `080498e021` (2025-04, "adds scrollbar to sidebar navigation"): the scrollbox became a classic, width-consuming `ScrollboxVertical`.

Release: the rail ships in 4.0; 3.0 is unaffected (its `sidebar-navigation` is a different component).

Reproduced locally on `v4.0.x-develop` @ `834ab7c107`, from source. With classic scrollbars visible, at 1280x560 (rail rendering 10 icons, moderator/presenter): scrollbox `offsetWidth 60 / clientWidth 55` (bar reserves 5px), `scrollHeight == clientHeight` (overflow 0, `scrollTop` cannot move), icons 35.75px, bar painted with a 99% thumb. At 1280x616 the content fits (39px icons, no bar); at 1280x519 and below there is real overflow, so the bar is legitimate. The ghost only exists in the narrow band in between, and how narrow that band is depends on how many icons the rail renders.

## Implementation

The fix targets the desktop rail only and keeps the shared `ScrollboxVertical` untouched.

1. `bigbluebutton-html5/imports/ui/components/sidebar-navigation/styles.ts`
   Reserve the scrollbar gutter on the rail scrollbox when not mobile: `scrollbar-gutter: stable both-edges`. This makes the scrollbox content width independent of whether a bar is drawn, so the bar can no longer change the icon size. `both-edges` reserves symmetric space, which keeps the icons perfectly centered: on a tall window the icons keep the same 39px size and the same centres as before, and the only rendered difference is that the two group separator lines are 5px narrower (they are sized from the scrollbox content box, which now excludes the reserved gutter). Desktop-only, gated on the existing `isMobile` prop.

2. `bigbluebutton-html5/imports/ui/components/sidebar-navigation/sidebar-navigation-button/styles.ts`
   Give the icon buttons a fixed desktop size instead of a width-derived percentage, so their size no longer feeds back from the scrollbar. The desktop base becomes `calc(39rem / 14)` (39px, the current effective size), and the responsive `65%` is restored for mobile via `@media (max-width: 40em)` - the codebase's canonical `smallOnly` breakpoint, already used for small-screen styling in these same rail files. The JS `isMobile` device type switches a little earlier (600px), so in a 600-640px-wide window the rail keeps the gutter while the buttons take the responsive width; the fix's invariant still holds there, because the gutter is constant and a scrollbar can only appear on real overflow.

3. `bigbluebutton-html5/imports/ui/stylesheets/styled-components/general.js`
   Add the `navigationSidebarListItemsWidthDesktop = 'calc(39rem / 14)'` token next to the existing `navigationSidebar*` tokens.

4. `bigbluebutton-html5/imports/ui/components/sidebar-navigation/component.tsx`
   Add `data-test="sidebarNavigationScrollbox"` to the scrollbox so the new tests have a stable hook.

Why this approach: it breaks the loop by construction with a small, rail-scoped diff, keeps the icon size constant at all heights (so a zero-overflow bar can never stabilize), and does not touch the shared `ScrollboxVertical` used by chat / user list / panels.

Note on font-size coupling: the desktop size is `min(calc(39rem / 14), 100%)`. The `calc(39rem / 14)` part is expressed in rem, so it follows the user font-size setting (12 to 20px, applied to the html root element); before this change the desktop icon size was derived from the rail width and did not follow the setting at all. The `100%` caps the icon at the scrollbox content box, which is the fixed 60px rail minus the 20px reserved scrollbar gutter, so 40px. Measured live with real (space-consuming) scrollbars, sweeping the html root through 12, 14, 16, 18 and 20px, the icon is 33.42px, 39px, 40px, 40px and 40px, and the scrollbox reports no horizontal overflow at any of those settings (scrollWidth equals clientWidth, 40px). Without the cap the same sweep gives 44.56px, 50.14px and 55.70px at 16, 18 and 20px, overflowing the 40px content box by 2, 5 and 8px.

Alternatives considered:
- Gutter only, keeping `65%`: fixes the loop but shrinks the icons to 35.75px on every desktop window (a visible design regression). Rejected.
- Single-edge `scrollbar-gutter: stable`: keeps the 39px size but shifts the icon column 2.5px off-centre on every window. Rejected in favour of `both-edges`, which keeps the icon column centred: comparing the tall-window rail screenshots pixel by pixel, 10 of 42,456 pixels differ, all of them on the two group separator lines.
- Detaching the icon size from width without the gutter: the bar would still shift the layout when it appears. Used together with the gutter instead.

## Test Coverage

New file `bigbluebutton-tests/playwright/layouts/sidebarNavigation.spec.ts` (page object in `layouts/sidebarNavigation.ts`), tag `@ci`, linked to issue 25564.

- Name: "Icon buttons keep their size when the rail enters the ghost-scrollbar band"
  Objective: prove the ghost bar's feedback loop is gone.
  Config: 1 moderator (presenter), own Chromium launched with `ignoreDefaultArgs: ['--hide-scrollbars']` so classic scrollbars behave like real desktop Chrome.
  Scenario: measure the icon width at 1280x616 (tall) and at 1280x550 (the old ghost band).
  Assertions: icon width at the ghost band equals the tall-regime width; the last icon is reachable (fits, or scrolls on real overflow).
  Expected: pass after the fix (39px == 39px); before the fix it fails (39px vs 35.75px).

- Name: "Rail stays correct across viewport resizes (bar only on real overflow)"
  Objective: the real field trigger (window resizing) stays correct.
  Config: 1 moderator, own Chromium with visible scrollbars.
  Scenario: sweep 1280 x {616, 590, 560, 550, 520, 490, 460}, then back to 616.
  Assertions: icon width constant across every height; at 1280x460 the content really overflows and the last icon is scroll-reachable; back at 616 there is no residual overflow and the icon size is restored.
  Expected: pass after the fix; before the fix it fails at 1280x560 (icon shrinks to 35.75px).

- Name: "Sidebar navigation scrolls only when the content really overflows"
  Objective: CI-safe height-budget guard on the default (scrollbars-hidden) browser.
  Config: 1 moderator, default browser.
  Scenario: measure at 1280x616 and 1280x460.
  Assertions: content fits without scroll when tall; overflows and the last icon is scroll-reachable when short.
  Expected: pass. Note: on the default browser Playwright hides scrollbars, so this test cannot see the ghost bar itself; it guards the height budget and reachability. The ghost bar is covered by the two tests above, which launch their own browser with scrollbars visible and still run headless in CI (no `@only-headed`, which CI excludes).

## Manual Test Cases

All desktop rows were run on a moderator/presenter whose rail renders 10 icons, unless the row says otherwise.

| Scenario | Expected result | Observed result |
|---|---|---|
| 1280x720 maximized, default meeting (issue's named case) | No scrollbar, all icons visible, full-size icons | Pass - clean rail, icons 39px, `scrollHeight == clientHeight`, no bar painted |
| 1280x682 | No bar, icons full size | Pass - overflow 0, icons 39px, no bar painted |
| 1280x616 | No bar, icons full size | Pass - overflow 0, icons 39px, no bar painted |
| Old ghost band, 1280x560 | No zero-overflow scrollbar; icons full size | Pass - icons stay 39px at every height. With 10 icons the 39px stack genuinely overflows by 4px at this height (`scrollHeight` 498 vs `clientHeight` 494), so a real, functional scrollbar is painted: near-full thumb, backed by real overflow, and `scrollTop` moves. What is gone is the zero-overflow ghost: before the fix the same window painted a bar over content that could not scroll, with the icons shrunk to 35.75px. With 9 icons (a moderator who is not the presenter) the content fits at this height and no bar is painted at all |
| Very short window 1280x460 | Real scrollbar, partial thumb, last icon reachable | Pass - overflow 104px, thumb covers 79% of the track (matching `clientHeight/scrollHeight` = 394/498), scrolls to the last icon |
| Dynamic resize down into overflow and back | Icon size constant; bar only on real overflow; no residual bar | Pass (automated Spec C) |
| Mobile (400x740), expand/collapse rail | No gutter; icons keep responsive 65%; toggle animation intact | Pass - `scrollbar-gutter: auto`, icon 31.2px (unchanged) |
| Dark mode, tall window | Scroll gradient only on real scroll | Pass - background gradient off when content fits |
| Chat / user list scrollbars | Unchanged | Pass - shared `ScrollboxVertical` not modified |
| RTL smoke, 1280x560 | Rail intact, icons full size, bar only on real overflow | Pass - icons 39px, symmetric gutter, bar mirrors to the left edge of the scrollbox and is backed by the same real 4px overflow |

## Evidence

Captured on one from-source 4.0 server, with classic scrollbars visible: "before" is the build of the parent commit `834ab7c107`, "after" is the build of this branch, deployed to the same host and captured by the same script.

Before and after use the same window heights and the same **pinned icon count**: the capture reads the rail buttons from the DOM and aborts unless the meeting renders exactly 10 icons. That matters because the icon count decides whether the stack overflows in the 5xx band, so a before/after pair taken on meetings with different counts is not comparable. Each still was verified at capture time against a DOM readout (icon width, `scrollHeight`/`clientHeight`, `offsetWidth - clientWidth`, how far `scrollTop` can move) plus a pixel check of the rail's right-hand strip, which measures whether a bar is painted and what fraction of the track the thumb covers.

Stills (rail only, 10 icons unless stated):

- Before, 1280x560: grey bar painted with a 99% thumb over content that has **zero** overflow (`scrollHeight` 494 == `clientHeight` 494, `scrollTop` cannot move), icons shrunk to 35.75px. This is the ghost.
- After, 1280x560: icons back to 39px; the taller stack now overflows by 4px (`scrollHeight` 498 vs `clientHeight` 494), so the bar that is painted is real - near-full thumb, and the rail actually scrolls. The ghost is gone, the bar is not.
- After, 1280x560 with 9 icons (a moderator who is not the presenter): content fits, icons 39px, no bar painted at all.
- After, 1280x720 (the issue's named resolution), 1280x682 and 1280x616: clean rail, no bar, icons 39px.
- After, 1280x460 (genuinely short): honest partial bar, thumb at 79% of the track, scrolls to the last icon.
- `comparison.png`: BEFORE 560 / AFTER 560 / AFTER 720 / AFTER 460 side by side, all with 10 icons.

Full-client sweep videos (before / after, same script and same timings, 10 icons). The recording canvas is fixed at 1280x720 while the window shrinks, so the grey area under the client is the recorder's background, not part of the page:

- 00:00:15 - 1280x616: no bar in either build.
- 00:00:19 - 1280x560, the old ghost band: before, the bar sits over a stack that cannot scroll, and the icons are visibly smaller; after, the icons are back to full size and the same-looking bar is backed by a real 4px overflow.
- 00:00:24 - 1280x460: real overflow in both builds; the after thumb is shorter (79% vs 84% of the track) because the icons kept their full size.
- 00:00:27 - the rail is scrolled at 1280x460 and reaches the last icon.
- 00:00:31 - back to 1280x720: no bar in either build, and no bar left over from the resize.

Also included:

- Sweep GIFs (before / after): the rail-only crop of the same run, stepping through 616 / 560 / 460 and back to 720.
- Automated tests: failing before the fix (icon 39px vs 35.75px) and passing after (4/4, including setup).

## Risks / Notes

- Browser support: `scrollbar-gutter` is supported in Chromium 94+ and Firefox 97+; Safari supports it from 18.2. Older Safari ignores the property and falls back to today's behavior; on macOS overlay scrollbars do not consume width, so the ghost bar does not occur there anyway. Graceful degradation.
- Scope is desktop, matching the issue. The mobile rail (48px) uses the same width-derived sizing but is out of scope here; it keeps its current behavior (no gutter, responsive `65%`) and is a known limitation, not addressed in this PR.
- Left unchanged on purpose: the `(max-height: 40em)` breakpoint (only adjusts gaps/icon font, not the loop) and the always-painted track of the shared `ScrollboxVertical` (changing it would affect chat / user list / panels). Both stay as they are; neither is needed to close the ghost-scrollbar loop.
- The fixed desktop size uses the `calc(Xrem / 14)` idiom already used by the neighbouring rail tokens, so it scales with the client root font exactly like the existing gaps and icons.

Evidence links:

- Comparison (before 560 / after 560 / after 720 / after 460, 10 icons each):

  ![comparison](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-08-20/5cff39c0-45c2-4803-8241-c71b8162d644/comparison.png)

- Rail sweep, before (720 into 460; watch 560: bar over a stack that cannot scroll, icons shrunk):

  ![before sweep](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-08-20/6f70e065-bc81-4ae1-a8af-d093e02950b5/before-sweep.gif)

- Rail sweep, after (icons full size at every height; bar only on real overflow):

  ![after sweep](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-08-20/84db9271-5eda-4818-8f08-8cc0abbe1a69/after-sweep.gif)

Animated previews above - click a GIF to open the matching full-client MP4 (higher quality, with controls):

- Before (full client): [before-fullclient.mp4](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-08-20/b7ca88a1-fd5b-48a4-989b-9dfcec3f07ba/before-fullclient.mp4)
- After (full client): [after-fullclient.mp4](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-08-20/8380857d-29c6-40f0-ad23-5e041a5b49ab/after-fullclient.mp4)

